### PR TITLE
Fixed bug in `Rule::update_refs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A research project of meta parsing and composing for data"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs)]
+#![feature(std_misc)]
 
 //! Meta parsing and encoding for data oriented design
 


### PR DESCRIPTION
The rules that used to replace names with references might themselves
contain names to other rules, which needs to be visited.
- Requires Rust-nightly since `BorrowState` is unstable.
