### PR TITLE
Fixed bug in `Lines`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A research project of meta parsing and composing for data"

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -13,6 +13,8 @@ pub enum ParseError {
     NotSupported,
     /// Whitespace is required.
     ExpectedWhitespace(DebugId),
+    /// New line is required.
+    ExpectedNewLine(DebugId),
     /// Something is required.
     ExpectedSomething(DebugId),
     /// Expected number.
@@ -38,6 +40,9 @@ impl Display for ParseError {
                 try!(fmt.write_str("This feature is not supported")),
             &ParseError::ExpectedWhitespace(debug_id) =>
                 try!(write!(fmt, "#{}, Expected whitespace",
+                    debug_id)),
+            &ParseError::ExpectedNewLine(debug_id) =>
+                try!(write!(fmt, "#{}, Expected new line",
                     debug_id)),
             &ParseError::ExpectedSomething(debug_id) =>
                 try!(write!(fmt, "#{}, Expected something",


### PR DESCRIPTION
Rules must be separated by new lines, but if the last rule consumed a
new line at the end it is not required.
