### PR TITLE
Fixed some bugs in `ParseStdErr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A research project of meta parsing and composing for data"

--- a/src/parse_error_handler.rs
+++ b/src/parse_error_handler.rs
@@ -18,7 +18,7 @@ impl<'a> ParseStdErr<'a> {
     pub fn new(text: &'a str) -> ParseStdErr<'a> {
         let mut start = 0;
         let mut lines = vec![];
-        for line in text.lines() {
+        for line in text.split('\n') {
             let length = line.len();
             lines.push((Range::new(start, length), line));
             // Lines are separated by '\n'.
@@ -44,6 +44,7 @@ impl<'b> ParseErrorHandler for ParseStdErr<'b> {
             for (i, &(r, _)) in err_handler.lines.iter().enumerate() {
                 if let Some(intersect) = range.ends_intersect(&r) {
                     first_line = Some((i, intersect));
+                    break;
                 }
             }
             first_line


### PR DESCRIPTION
- `first_line` not breaking on first
- split lines by ‘\n’ instead of using `.lines()`
