### PR TITLE
Removed `ParseError::NotSupported`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A research project of meta parsing and composing for data"

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -9,8 +9,6 @@ use DebugId;
 /// Errors reporting expected values.
 #[derive(Debug, PartialEq)]
 pub enum ParseError {
-    /// Not supported.
-    NotSupported,
     /// Whitespace is required.
     ExpectedWhitespace(DebugId),
     /// New line is required.
@@ -40,8 +38,6 @@ pub enum ParseError {
 impl Display for ParseError {
     fn fmt(&self, fmt: &mut Formatter) -> Result<(), FormatError> {
         match self {
-            &ParseError::NotSupported =>
-                try!(fmt.write_str("This feature is not supported")),
             &ParseError::ExpectedWhitespace(debug_id) =>
                 try!(write!(fmt, "#{}, Expected whitespace",
                     debug_id)),


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/meta/issues/178
