### PR TITLE
Update to read_token 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A DSL parsing library for human readable text documents"
@@ -11,7 +11,7 @@ repository = "https://github.com/pistondevelopers/meta.git"
 homepage = "https://github.com/pistondevelopers/meta"
 
 [dependencies]
-read_token = "0.1.2"
+read_token = "0.2.0"
 range = "0.1.1"
 
 [features]

--- a/src/meta_rules/number.rs
+++ b/src/meta_rules/number.rs
@@ -33,22 +33,13 @@ impl Number {
         chars: &[char],
         offset: usize
     ) -> ParseResult<TokenizerState> {
-        let res = if self.allow_underscore {
-                read_token::underscore_number(chars, offset)
-            } else {
-                read_token::number(chars, offset)
-            };
-        if let Some(range) = res {
-            let mut text = String::with_capacity(range.length);
-            for c in chars.iter()
-                .take(range.length)
-                .filter(|&c| *c != '_')
-            {
-                text.push(*c);
-            }
-            match text.parse::<f64>() {
+        let settings = read_token::NumberSettings {
+            allow_underscore: self.allow_underscore
+        };
+        if let Some(range) = read_token::number(&settings, chars, offset) {
+            match read_token::parse_number(&settings, &chars[..range.length]) {
                 Err(err) => Err((range,
-                    ParseError::ParseFloatError(err, self.debug_id))),
+                    ParseError::ParseNumberError(err, self.debug_id))),
                 Ok(val) => {
                     if let Some(ref property) = self.property {
                         Ok((range, tokenizer.data(

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -1,7 +1,6 @@
 use std::fmt::{ Display, Formatter };
 use std::fmt::Error as FormatError;
-use std::num::ParseFloatError;
-use read_token::ParseStringError;
+use read_token::{ ParseNumberError, ParseStringError };
 use std::rc::Rc;
 
 use DebugId;
@@ -18,7 +17,7 @@ pub enum ParseError {
     /// Expected number.
     ExpectedNumber(DebugId),
     /// Error when parsing float.
-    ParseFloatError(ParseFloatError, DebugId),
+    ParseNumberError(ParseNumberError, DebugId),
     /// Expected text.
     ExpectedText(DebugId),
     /// Empty text not allowed.
@@ -49,7 +48,7 @@ impl Display for ParseError {
                     debug_id)),
             &ParseError::ExpectedNumber(debug_id) =>
                 try!(write!(fmt, "#{}, Expected number", debug_id)),
-            &ParseError::ParseFloatError(ref err, debug_id) =>
+            &ParseError::ParseNumberError(ref err, debug_id) =>
                 try!(write!(fmt, "#{}, Invalid number format: {}",
                     debug_id, err)),
             &ParseError::ExpectedToken(ref token, debug_id) =>


### PR DESCRIPTION
- Avoid allocation when parsing numbers
- Should work on stable Rust now
- Bumped to 0.8.0
