### PR TITLE
Fixed bug

### DIFF
--- a/src/meta_rules/mod.rs
+++ b/src/meta_rules/mod.rs
@@ -56,7 +56,7 @@ pub fn parse(
     match res {
         Ok((range, s, opt_error)) => {
             // Report error if did not reach the end of text.
-            if range.next_offset() < text.len() {
+            if range.next_offset() < text.chars().count() {
                 Err(ret_err(
                     (Range::empty(range.next_offset()),
                         ParseError::ExpectedEnd),


### PR DESCRIPTION
- Replaced `text.len` with `text.chars().count()`
