### PR TITLE
Switch from `Rc<String>` to `Arc<String>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A DSL parsing library for human readable text documents"

--- a/src/bootstrap/convert.rs
+++ b/src/bootstrap/convert.rs
@@ -20,6 +20,7 @@ use meta_rules::{
     Whitespace,
 };
 use MetaData;
+use Syntax;
 
 /// Updates with parsed range.
 pub fn update(range: Range, data: &mut &[(Range, MetaData)], offset: &mut usize) {
@@ -110,7 +111,7 @@ pub fn meta_bool(name: &str, data: &[(Range, MetaData)], offset: usize)
 pub fn convert(
     mut data: &[(Range, MetaData)],
     ignored: &mut Vec<Range>
-) -> Result<Vec<(Arc<String>, Rule)>, ()> {
+) -> Result<Syntax, ()> {
     fn read_string(mut data: &[(Range, MetaData)], mut offset: usize)
     -> Result<(Range, (Arc<String>, Arc<String>)), ()> {
         let start_offset = offset;
@@ -838,7 +839,7 @@ pub fn convert(
             break;
         }
     }
-    let mut res = vec![];
+    let mut res = Syntax::new();
     loop {
         if let Ok((range, val)) = read_node(data, offset, &strings, ignored) {
             update(range, &mut data, &mut offset);
@@ -849,6 +850,6 @@ pub fn convert(
             break;
         }
     }
-    update_refs(&res);
+    update_refs(&mut res);
     Ok(res)
 }

--- a/src/bootstrap/convert.rs
+++ b/src/bootstrap/convert.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::cell::Cell;
 use range::Range;
 
 use meta_rules::{
@@ -500,7 +499,7 @@ pub fn convert(
                     debug_id: *debug_id,
                     name: name,
                     property: property,
-                    index: Cell::new(None),
+                    index: None,
                 })))
             }
             None => Err(())

--- a/src/bootstrap/convert.rs
+++ b/src/bootstrap/convert.rs
@@ -842,7 +842,7 @@ pub fn convert(
     loop {
         if let Ok((range, val)) = read_node(data, offset, &strings, ignored) {
             update(range, &mut data, &mut offset);
-            res.push(val);
+            res.push(val.0, val.1);
         } else if offset < data.len() {
             return Err(());
         } else {

--- a/src/bootstrap/convert.rs
+++ b/src/bootstrap/convert.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 use std::cell::Cell;
 use range::Range;
 
@@ -72,7 +72,7 @@ pub fn ignore(data: &[(Range, MetaData)], offset: usize)
 
 /// Reads string.
 pub fn meta_string(name: &str, data: &[(Range, MetaData)], offset: usize)
--> Result<(Range, Rc<String>), ()> {
+-> Result<(Range, Arc<String>), ()> {
     if data.len() == 0 { return Err(()); }
     match &data[0].1 {
         &MetaData::String(ref n, ref val) if &**n == name => {
@@ -110,9 +110,9 @@ pub fn meta_bool(name: &str, data: &[(Range, MetaData)], offset: usize)
 pub fn convert(
     mut data: &[(Range, MetaData)],
     ignored: &mut Vec<Range>
-) -> Result<Vec<(Rc<String>, Rule)>, ()> {
+) -> Result<Vec<(Arc<String>, Rule)>, ()> {
     fn read_string(mut data: &[(Range, MetaData)], mut offset: usize)
-    -> Result<(Range, (Rc<String>, Rc<String>)), ()> {
+    -> Result<(Range, (Arc<String>, Arc<String>)), ()> {
         let start_offset = offset;
         let range = try!(start_node("string", data, offset));
         update(range, &mut data, &mut offset);
@@ -147,7 +147,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -177,13 +177,13 @@ pub fn convert(
         })))
     }
 
-    fn find_string(val: &str, strings: &[(Rc<String>, Rc<String>)]) -> Option<Rc<String>> {
+    fn find_string(val: &str, strings: &[(Arc<String>, Arc<String>)]) -> Option<Arc<String>> {
         strings.iter().find(|&&(ref s, _)| &**s == val).map(|&(_, ref s)| s.clone())
     }
 
     fn read_set(property: &str, mut data: &[(Range, MetaData)], mut offset: usize,
-    strings: &[(Rc<String>, Rc<String>)])
-    -> Result<(Range, Rc<String>), ()> {
+    strings: &[(Arc<String>, Arc<String>)])
+    -> Result<(Range, Arc<String>), ()> {
         let start_offset = offset;
         let range = try!(start_node(property, data, offset));
         update(range, &mut data, &mut offset);
@@ -212,7 +212,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -261,7 +261,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -310,7 +310,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -386,7 +386,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -425,7 +425,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -465,7 +465,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -510,7 +510,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -545,7 +545,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -570,7 +570,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -629,7 +629,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -653,7 +653,7 @@ pub fn convert(
         debug_id: &mut usize,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -701,7 +701,7 @@ pub fn convert(
         property: &str,
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
     ) -> Result<(Range, Rule), ()> {
         let start_offset = offset;
@@ -788,9 +788,9 @@ pub fn convert(
     fn read_node(
         mut data: &[(Range, MetaData)],
         mut offset: usize,
-        strings: &[(Rc<String>, Rc<String>)],
+        strings: &[(Arc<String>, Arc<String>)],
         ignored: &mut Vec<Range>
-    ) -> Result<(Range, (Rc<String>, Rule)), ()> {
+    ) -> Result<(Range, (Arc<String>, Rule)), ()> {
         let start_offset = offset;
         let node = "node";
         let range = try!(start_node(node, data, offset));
@@ -828,7 +828,7 @@ pub fn convert(
         }
     }
 
-    let mut strings: Vec<(Rc<String>, Rc<String>)> = vec![];
+    let mut strings: Vec<(Arc<String>, Arc<String>)> = vec![];
     let mut offset: usize = 0;
     loop {
         if let Ok((range, val)) = read_string(data, offset) {

--- a/src/bootstrap/rules.rs
+++ b/src/bootstrap/rules.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 use std::cell::Cell;
 
 use meta_rules::{
@@ -18,12 +18,12 @@ use meta_rules::{
 };
 
 /// Returns rules for parsing meta rules.
-pub fn rules() -> Vec<(Rc<String>, Rule)> {
-    let opt: Rc<String> = Rc::new("optional".into());
-    let inv: Rc<String> = Rc::new("inverted".into());
-    let prop: Rc<String> = Rc::new("property".into());
-    let any: Rc<String> = Rc::new("any_characters".into());
-    let seps: Rc<String> = Rc::new("[]{}():.!?\"".into());
+pub fn rules() -> Vec<(Arc<String>, Rule)> {
+    let opt: Arc<String> = Arc::new("optional".into());
+    let inv: Arc<String> = Arc::new("inverted".into());
+    let prop: Arc<String> = Arc::new("property".into());
+    let any: Arc<String> = Arc::new("any_characters".into());
+    let seps: Arc<String> = Arc::new("[]{}():.!?\"".into());
 
     // 1 "string" [w? ..seps!"name" ":" w? t?"text"]
     let string_rule = Rule::Sequence(Sequence {
@@ -37,11 +37,11 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 debug_id: 1003,
                 any_characters: seps.clone(),
                 optional: false,
-                property: Some(Rc::new("name".into()))
+                property: Some(Arc::new("name".into()))
             }),
             Rule::Token(Token {
                 debug_id: 1004,
-                text: Rc::new(":".into()),
+                text: Arc::new(":".into()),
                 not: false,
                 inverted: false,
                 property: None
@@ -53,7 +53,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             Rule::Text(Text {
                 debug_id: 1006,
                 allow_empty: true,
-                property: Some(Rc::new("text".into())),
+                property: Some(Arc::new("text".into())),
             })
         ]
     });
@@ -69,7 +69,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             Rule::Number(Number {
                 debug_id: 2003,
                 allow_underscore: false,
-                property: Some(Rc::new("id".into())),
+                property: Some(Arc::new("id".into())),
             }),
             Rule::Whitespace(Whitespace {
                 debug_id: 2004,
@@ -78,7 +78,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             Rule::Text(Text {
                 debug_id: 2005,
                 allow_empty: false,
-                property: Some(Rc::new("name".into())),
+                property: Some(Arc::new("name".into())),
             }),
             Rule::Whitespace(Whitespace {
                 debug_id: 2006,
@@ -86,8 +86,8 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             }),
             Rule::Node(Node {
                 debug_id: 2007,
-                name: Rc::new("rule".into()),
-                property: Some(Rc::new("rule".into())),
+                name: Arc::new("rule".into()),
+                property: Some(Arc::new("rule".into())),
                 index: Cell::new(None),
             })
         ]
@@ -100,13 +100,13 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             Rule::Text(Text {
                 debug_id: 3002,
                 allow_empty: false,
-                property: Some(Rc::new("value".into())),
+                property: Some(Arc::new("value".into())),
             }),
             Rule::UntilAnyOrWhitespace(UntilAnyOrWhitespace {
                 debug_id: 3003,
                 any_characters: seps.clone(),
                 optional: false,
-                property: Some(Rc::new("ref".into())),
+                property: Some(Arc::new("ref".into())),
             })
         ]
     });
@@ -118,13 +118,13 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             Rule::Text(Text {
                 debug_id: 4002,
                 allow_empty: true,
-                property: Some(Rc::new("value".into())),
+                property: Some(Arc::new("value".into())),
             }),
             Rule::UntilAnyOrWhitespace(UntilAnyOrWhitespace {
                 debug_id: 4003,
                 any_characters: seps.clone(),
                 optional: false,
-                property: Some(Rc::new("ref".into())),
+                property: Some(Arc::new("ref".into())),
             })
         ]
     });
@@ -135,14 +135,14 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 5002,
-                text: Rc::new("?".into()),
+                text: Arc::new("?".into()),
                 not: false,
                 inverted: false,
                 property: Some(opt.clone())
             }),
             Rule::Token(Token {
                 debug_id: 5003,
-                text: Rc::new("!".into()),
+                text: Arc::new("!".into()),
                 not: false,
                 inverted: true,
                 property: Some(opt.clone())
@@ -156,7 +156,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 6002,
-                text: Rc::new("$".into()),
+                text: Arc::new("$".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -165,18 +165,18 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 debug_id: 6003,
                 rule: Rule::Token(Token {
                     debug_id: 6004,
-                    text: Rc::new("_".into()),
+                    text: Arc::new("_".into()),
                     not: false,
                     inverted: false,
-                    property: Some(Rc::new("underscore".into()))
+                    property: Some(Arc::new("underscore".into()))
                 })
             })),
             Rule::Optional(Box::new(Optional {
                 debug_id: 6005,
                 rule: Rule::Node(Node {
                     debug_id: 6006,
-                    name: Rc::new("set".into()),
-                    property: Some(Rc::new("property".into())),
+                    name: Arc::new("set".into()),
+                    property: Some(Arc::new("property".into())),
                     index: Cell::new(None),
                 })
             }))
@@ -189,7 +189,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 7002,
-                text: Rc::new("t".into()),
+                text: Arc::new("t".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -199,17 +199,17 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 args: vec![
                     Rule::Token(Token {
                         debug_id: 7004,
-                        text: Rc::new("?".into()),
+                        text: Arc::new("?".into()),
                         not: false,
                         inverted: false,
-                        property: Some(Rc::new("allow_empty".into())),
+                        property: Some(Arc::new("allow_empty".into())),
                     }),
                     Rule::Token(Token {
                         debug_id: 7005,
-                        text: Rc::new("!".into()),
+                        text: Arc::new("!".into()),
                         not: false,
                         inverted: true,
-                        property: Some(Rc::new("allow_empty".into())),
+                        property: Some(Arc::new("allow_empty".into())),
                     })
                 ]
             }),
@@ -217,7 +217,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 debug_id: 7006,
                 rule: Rule::Node(Node {
                     debug_id: 7007,
-                    name: Rc::new("set".into()),
+                    name: Arc::new("set".into()),
                     property: Some(prop.clone()),
                     index: Cell::new(None),
                 })
@@ -231,7 +231,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 8002,
-                text: Rc::new("@".into()),
+                text: Arc::new("@".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -239,13 +239,13 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             Rule::Text(Text {
                 debug_id: 8003,
                 allow_empty: false,
-                property: Some(Rc::new("name".into())),
+                property: Some(Arc::new("name".into())),
             }),
             Rule::Optional(Box::new(Optional {
                 debug_id: 8004,
                 rule: Rule::Node(Node {
                     debug_id: 8005,
-                    name: Rc::new("set".into()),
+                    name: Arc::new("set".into()),
                     property: Some(prop.clone()),
                     index: Cell::new(None)
                 })
@@ -259,7 +259,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 9002,
-                text: Rc::new("[".into()),
+                text: Arc::new("[".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -278,14 +278,14 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 }),
                 rule: Rule::Node(Node {
                     debug_id: 9006,
-                    name: Rc::new("rule".into()),
-                    property: Some(Rc::new("rule".into())),
+                    name: Arc::new("rule".into()),
+                    property: Some(Arc::new("rule".into())),
                     index: Cell::new(None)
                 })
             })),
             Rule::Token(Token {
                 debug_id: 9007,
-                text: Rc::new("]".into()),
+                text: Arc::new("]".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -299,7 +299,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 10002,
-                text: Rc::new("{".into()),
+                text: Arc::new("{".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -318,14 +318,14 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 }),
                 rule: Rule::Node(Node {
                     debug_id: 10006,
-                    name: Rc::new("rule".into()),
-                    property: Some(Rc::new("rule".into())),
+                    name: Arc::new("rule".into()),
+                    property: Some(Arc::new("rule".into())),
                     index: Cell::new(None),
                 })
             })),
             Rule::Token(Token {
                 debug_id: 10007,
-                text: Rc::new("}".into()),
+                text: Arc::new("}".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -340,14 +340,14 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 11002,
-                text: Rc::new("s".into()),
+                text: Arc::new("s".into()),
                 not: false,
                 inverted: false,
                 property: None,
             }),
             Rule::Node(Node {
                 debug_id: 11003,
-                name: Rc::new("opt".into()),
+                name: Arc::new("opt".into()),
                 property: None,
                 index: Cell::new(None),
             }),
@@ -355,15 +355,15 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 debug_id: 11004,
                 rule: Rule::Token(Token {
                     debug_id: 11005,
-                    text: Rc::new(".".into()),
+                    text: Arc::new(".".into()),
                     not: false,
                     inverted: false,
-                    property: Some(Rc::new("allow_trail".into())),
+                    property: Some(Arc::new("allow_trail".into())),
                 })
             })),
             Rule::Token(Token {
                 debug_id: 11006,
-                text: Rc::new("(".into()),
+                text: Arc::new("(".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -374,8 +374,8 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             }),
             Rule::Node(Node {
                 debug_id: 11008,
-                name: Rc::new("rule".into()),
-                property: Some(Rc::new("by".into())),
+                name: Arc::new("rule".into()),
+                property: Some(Arc::new("by".into())),
                 index: Cell::new(None),
             }),
             Rule::Whitespace(Whitespace {
@@ -384,7 +384,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             }),
             Rule::Token(Token {
                 debug_id: 11010,
-                text: Rc::new(")".into()),
+                text: Arc::new(")".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -395,7 +395,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             }),
             Rule::Token(Token {
                 debug_id: 11012,
-                text: Rc::new("{".into()),
+                text: Arc::new("{".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -406,8 +406,8 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             }),
             Rule::Node(Node {
                 debug_id: 11014,
-                name: Rc::new("rule".into()),
-                property: Some(Rc::new("rule".into())),
+                name: Arc::new("rule".into()),
+                property: Some(Arc::new("rule".into())),
                 index: Cell::new(None),
             }),
             Rule::Whitespace(Whitespace {
@@ -416,7 +416,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             }),
             Rule::Token(Token {
                 debug_id: 11016,
-                text: Rc::new("}".into()),
+                text: Arc::new("}".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -432,16 +432,16 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 debug_id: 12002,
                 rule: Rule::Token(Token {
                     debug_id: 12003,
-                    text: Rc::new("!".into()),
+                    text: Arc::new("!".into()),
                     not: false,
                     inverted: false,
-                    property: Some(Rc::new("not".into()))
+                    property: Some(Arc::new("not".into()))
                 })
             })),
             Rule::Node(Node {
                 debug_id: 12004,
-                name: Rc::new("set".into()),
-                property: Some(Rc::new("text".into())),
+                name: Arc::new("set".into()),
+                property: Some(Arc::new("text".into())),
                 index: Cell::new(None),
             }),
             Rule::Optional(Box::new(Optional {
@@ -453,7 +453,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                             debug_id: 12007,
                             rule: Rule::Token(Token {
                                 debug_id: 12008,
-                                text: Rc::new("!".into()),
+                                text: Arc::new("!".into()),
                                 not: false,
                                 inverted: false,
                                 property: Some(inv.clone()),
@@ -461,7 +461,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                         })),
                         Rule::Node(Node {
                             debug_id: 12009,
-                            name: Rc::new("set".into()),
+                            name: Arc::new("set".into()),
                             property: Some(prop.clone()),
                             index: Cell::new(None),
                         })
@@ -477,15 +477,15 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 13002,
-                text: Rc::new("?".into()),
+                text: Arc::new("?".into()),
                 not: false,
                 inverted: false,
                 property: None,
             }),
             Rule::Node(Node {
                 debug_id: 13003,
-                name: Rc::new("rule".into()),
-                property: Some(Rc::new("rule".into())),
+                name: Arc::new("rule".into()),
+                property: Some(Arc::new("rule".into())),
                 index: Cell::new(None),
             })
         ]
@@ -497,14 +497,14 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 14002,
-                text: Rc::new("w".into()),
+                text: Arc::new("w".into()),
                 not: false,
                 inverted: false,
                 property: None,
             }),
             Rule::Node(Node {
                 debug_id: 14003,
-                name: Rc::new("opt".into()),
+                name: Arc::new("opt".into()),
                 property: None,
                 index: Cell::new(None),
             })
@@ -517,20 +517,20 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 15002,
-                text: Rc::new("..".into()),
+                text: Arc::new("..".into()),
                 not: false,
                 inverted: false,
                 property: None,
             }),
             Rule::Node(Node {
                 debug_id: 15003,
-                name: Rc::new("set_opt".into()),
+                name: Arc::new("set_opt".into()),
                 property: Some(any.clone()),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 15004,
-                name: Rc::new("opt".into()),
+                name: Arc::new("opt".into()),
                 property: None,
                 index: Cell::new(None),
             }),
@@ -538,7 +538,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 debug_id: 15005,
                 rule: Rule::Node(Node {
                     debug_id: 15006,
-                    name: Rc::new("set".into()),
+                    name: Arc::new("set".into()),
                     property: Some(prop.clone()),
                     index: Cell::new(None),
                 })
@@ -552,20 +552,20 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 16002,
-                text: Rc::new("...".into()),
+                text: Arc::new("...".into()),
                 not: false,
                 inverted: false,
                 property: None,
             }),
             Rule::Node(Node {
                 debug_id: 16003,
-                name: Rc::new("set_opt".into()),
+                name: Arc::new("set_opt".into()),
                 property: Some(any.clone()),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 16004,
-                name: Rc::new("opt".into()),
+                name: Arc::new("opt".into()),
                 property: None,
                 index: Cell::new(None),
             }),
@@ -573,7 +573,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 debug_id: 16005,
                 rule: Rule::Node(Node {
                     debug_id: 16006,
-                    name: Rc::new("set".into()),
+                    name: Arc::new("set".into()),
                     property: Some(prop.clone()),
                     index: Cell::new(None),
                 })
@@ -587,33 +587,33 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 17002,
-                text: Rc::new("r".into()),
+                text: Arc::new("r".into()),
                 not: false,
                 inverted: false,
                 property: None,
             }),
             Rule::Node(Node {
                 debug_id: 17003,
-                name: Rc::new("opt".into()),
+                name: Arc::new("opt".into()),
                 property: None,
                 index: Cell::new(None),
             }),
             Rule::Token(Token {
                 debug_id: 17004,
-                text: Rc::new("(".into()),
+                text: Arc::new("(".into()),
                 not: false,
                 inverted: false,
                 property: None,
             }),
             Rule::Node(Node {
                 debug_id: 17005,
-                name: Rc::new("rule".into()),
-                property: Some(Rc::new("rule".into())),
+                name: Arc::new("rule".into()),
+                property: Some(Arc::new("rule".into())),
                 index: Cell::new(None),
             }),
             Rule::Token(Token {
                 debug_id: 17006,
-                text: Rc::new(")".into()),
+                text: Arc::new(")".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -627,7 +627,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Token(Token {
                 debug_id: 18002,
-                text: Rc::new("l(".into()),
+                text: Arc::new("l(".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -638,8 +638,8 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             }),
             Rule::Node(Node {
                 debug_id: 18004,
-                name: Rc::new("rule".into()),
-                property: Some(Rc::new("rule".into())),
+                name: Arc::new("rule".into()),
+                property: Some(Arc::new("rule".into())),
                 index: Cell::new(None),
             }),
             Rule::Whitespace(Whitespace {
@@ -648,7 +648,7 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
             }),
             Rule::Token(Token {
                 debug_id: 18006,
-                text: Rc::new(")".into()),
+                text: Arc::new(")".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -678,80 +678,80 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
         args: vec![
             Rule::Node(Node {
                 debug_id: 19001,
-                name: Rc::new("whitespace".into()),
-                property: Some(Rc::new("whitespace".into())),
+                name: Arc::new("whitespace".into()),
+                property: Some(Arc::new("whitespace".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19002,
-                name: Rc::new("until_any_or_whitespace".into()),
-                property: Some(Rc::new("until_any_or_whitespace".into())),
+                name: Arc::new("until_any_or_whitespace".into()),
+                property: Some(Arc::new("until_any_or_whitespace".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19003,
-                name: Rc::new("until_any".into()),
-                property: Some(Rc::new("until_any".into())),
+                name: Arc::new("until_any".into()),
+                property: Some(Arc::new("until_any".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19004,
-                name: Rc::new("lines".into()),
-                property: Some(Rc::new("lines".into())),
+                name: Arc::new("lines".into()),
+                property: Some(Arc::new("lines".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19005,
-                name: Rc::new("repeat".into()),
-                property: Some(Rc::new("repeat".into())),
+                name: Arc::new("repeat".into()),
+                property: Some(Arc::new("repeat".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19006,
-                name: Rc::new("number".into()),
-                property: Some(Rc::new("number".into())),
+                name: Arc::new("number".into()),
+                property: Some(Arc::new("number".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19007,
-                name: Rc::new("text".into()),
-                property: Some(Rc::new("text".into())),
+                name: Arc::new("text".into()),
+                property: Some(Arc::new("text".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19008,
-                name: Rc::new("reference".into()),
-                property: Some(Rc::new("reference".into())),
+                name: Arc::new("reference".into()),
+                property: Some(Arc::new("reference".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19009,
-                name: Rc::new("sequence".into()),
-                property: Some(Rc::new("sequence".into())),
+                name: Arc::new("sequence".into()),
+                property: Some(Arc::new("sequence".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19010,
-                name: Rc::new("select".into()),
-                property: Some(Rc::new("select".into())),
+                name: Arc::new("select".into()),
+                property: Some(Arc::new("select".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19011,
-                name: Rc::new("separated_by".into()),
-                property: Some(Rc::new("separated_by".into())),
+                name: Arc::new("separated_by".into()),
+                property: Some(Arc::new("separated_by".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19012,
-                name: Rc::new("token".into()),
-                property: Some(Rc::new("token".into())),
+                name: Arc::new("token".into()),
+                property: Some(Arc::new("token".into())),
                 index: Cell::new(None),
             }),
             Rule::Node(Node {
                 debug_id: 19013,
-                name: Rc::new("optional".into()),
-                property: Some(Rc::new("optional".into())),
+                name: Arc::new("optional".into()),
+                property: Some(Arc::new("optional".into())),
                 index: Cell::new(None),
             }),
         ]
@@ -765,8 +765,8 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 debug_id: 20002,
                 rule: Rule::Node(Node {
                     debug_id: 20003,
-                    name: Rc::new("string".into()),
-                    property: Some(Rc::new("string".into())),
+                    name: Arc::new("string".into()),
+                    property: Some(Arc::new("string".into())),
                     index: Cell::new(None),
                 })
             })),
@@ -774,8 +774,8 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
                 debug_id: 20004,
                 rule: Rule::Node(Node {
                     debug_id: 20005,
-                    name: Rc::new("node".into()),
-                    property: Some(Rc::new("node".into())),
+                    name: Arc::new("node".into()),
+                    property: Some(Arc::new("node".into())),
                     index: Cell::new(None),
                 })
             })),
@@ -787,26 +787,26 @@ pub fn rules() -> Vec<(Rc<String>, Rule)> {
     });
 
     let rules = vec![
-        (Rc::new("string".into()), string_rule),
-        (Rc::new("node".into()), node_rule),
-        (Rc::new("set".into()), set_rule),
-        (Rc::new("set_opt".into()), set_opt_rule),
-        (Rc::new("opt".into()), opt_rule),
-        (Rc::new("number".into()), number_rule),
-        (Rc::new("text".into()), text_rule),
-        (Rc::new("reference".into()), reference_rule),
-        (Rc::new("sequence".into()), sequence_rule),
-        (Rc::new("select".into()), select_rule),
-        (Rc::new("separated_by".into()), separated_by_rule),
-        (Rc::new("token".into()), token_rule),
-        (Rc::new("optional".into()), optional_rule),
-        (Rc::new("whitespace".into()), whitespace_rule),
-        (Rc::new("until_any_or_whitespace".into()), until_any_or_whitespace_rule),
-        (Rc::new("until_any".into()), until_any_rule),
-        (Rc::new("repeat".into()), repeat_rule),
-        (Rc::new("lines".into()), lines_rule),
-        (Rc::new("rule".into()), rule_rule),
-        (Rc::new("document".into()), document_rule),
+        (Arc::new("string".into()), string_rule),
+        (Arc::new("node".into()), node_rule),
+        (Arc::new("set".into()), set_rule),
+        (Arc::new("set_opt".into()), set_opt_rule),
+        (Arc::new("opt".into()), opt_rule),
+        (Arc::new("number".into()), number_rule),
+        (Arc::new("text".into()), text_rule),
+        (Arc::new("reference".into()), reference_rule),
+        (Arc::new("sequence".into()), sequence_rule),
+        (Arc::new("select".into()), select_rule),
+        (Arc::new("separated_by".into()), separated_by_rule),
+        (Arc::new("token".into()), token_rule),
+        (Arc::new("optional".into()), optional_rule),
+        (Arc::new("whitespace".into()), whitespace_rule),
+        (Arc::new("until_any_or_whitespace".into()), until_any_or_whitespace_rule),
+        (Arc::new("until_any".into()), until_any_rule),
+        (Arc::new("repeat".into()), repeat_rule),
+        (Arc::new("lines".into()), lines_rule),
+        (Arc::new("rule".into()), rule_rule),
+        (Arc::new("document".into()), document_rule),
     ];
     update_refs(&rules);
     rules

--- a/src/bootstrap/rules.rs
+++ b/src/bootstrap/rules.rs
@@ -790,26 +790,26 @@ pub fn rules() -> Syntax {
         rules: Vec::with_capacity(20),
         names: Vec::with_capacity(20)
     };
-    syntax.push((Arc::new("string".into()), string_rule));
-    syntax.push((Arc::new("node".into()), node_rule));
-    syntax.push((Arc::new("set".into()), set_rule));
-    syntax.push((Arc::new("set_opt".into()), set_opt_rule));
-    syntax.push((Arc::new("opt".into()), opt_rule));
-    syntax.push((Arc::new("number".into()), number_rule));
-    syntax.push((Arc::new("text".into()), text_rule));
-    syntax.push((Arc::new("reference".into()), reference_rule));
-    syntax.push((Arc::new("sequence".into()), sequence_rule));
-    syntax.push((Arc::new("select".into()), select_rule));
-    syntax.push((Arc::new("separated_by".into()), separated_by_rule));
-    syntax.push((Arc::new("token".into()), token_rule));
-    syntax.push((Arc::new("optional".into()), optional_rule));
-    syntax.push((Arc::new("whitespace".into()), whitespace_rule));
-    syntax.push((Arc::new("until_any_or_whitespace".into()), until_any_or_whitespace_rule));
-    syntax.push((Arc::new("until_any".into()), until_any_rule));
-    syntax.push((Arc::new("repeat".into()), repeat_rule));
-    syntax.push((Arc::new("lines".into()), lines_rule));
-    syntax.push((Arc::new("rule".into()), rule_rule));
-    syntax.push((Arc::new("document".into()), document_rule));
+    syntax.push(Arc::new("string".into()), string_rule);
+    syntax.push(Arc::new("node".into()), node_rule);
+    syntax.push(Arc::new("set".into()), set_rule);
+    syntax.push(Arc::new("set_opt".into()), set_opt_rule);
+    syntax.push(Arc::new("opt".into()), opt_rule);
+    syntax.push(Arc::new("number".into()), number_rule);
+    syntax.push(Arc::new("text".into()), text_rule);
+    syntax.push(Arc::new("reference".into()), reference_rule);
+    syntax.push(Arc::new("sequence".into()), sequence_rule);
+    syntax.push(Arc::new("select".into()), select_rule);
+    syntax.push(Arc::new("separated_by".into()), separated_by_rule);
+    syntax.push(Arc::new("token".into()), token_rule);
+    syntax.push(Arc::new("optional".into()), optional_rule);
+    syntax.push(Arc::new("whitespace".into()), whitespace_rule);
+    syntax.push(Arc::new("until_any_or_whitespace".into()), until_any_or_whitespace_rule);
+    syntax.push(Arc::new("until_any".into()), until_any_rule);
+    syntax.push(Arc::new("repeat".into()), repeat_rule);
+    syntax.push(Arc::new("lines".into()), lines_rule);
+    syntax.push(Arc::new("rule".into()), rule_rule);
+    syntax.push(Arc::new("document".into()), document_rule);
     update_refs(&mut syntax);
     syntax
 }

--- a/src/bootstrap/rules.rs
+++ b/src/bootstrap/rules.rs
@@ -16,9 +16,10 @@ use meta_rules::{
     UntilAnyOrWhitespace,
     Whitespace,
 };
+use Syntax;
 
 /// Returns rules for parsing meta rules.
-pub fn rules() -> Vec<(Arc<String>, Rule)> {
+pub fn rules() -> Syntax {
     let opt: Arc<String> = Arc::new("optional".into());
     let inv: Arc<String> = Arc::new("inverted".into());
     let prop: Arc<String> = Arc::new("property".into());
@@ -786,28 +787,30 @@ pub fn rules() -> Vec<(Arc<String>, Rule)> {
         ]
     });
 
-    let rules = vec![
-        (Arc::new("string".into()), string_rule),
-        (Arc::new("node".into()), node_rule),
-        (Arc::new("set".into()), set_rule),
-        (Arc::new("set_opt".into()), set_opt_rule),
-        (Arc::new("opt".into()), opt_rule),
-        (Arc::new("number".into()), number_rule),
-        (Arc::new("text".into()), text_rule),
-        (Arc::new("reference".into()), reference_rule),
-        (Arc::new("sequence".into()), sequence_rule),
-        (Arc::new("select".into()), select_rule),
-        (Arc::new("separated_by".into()), separated_by_rule),
-        (Arc::new("token".into()), token_rule),
-        (Arc::new("optional".into()), optional_rule),
-        (Arc::new("whitespace".into()), whitespace_rule),
-        (Arc::new("until_any_or_whitespace".into()), until_any_or_whitespace_rule),
-        (Arc::new("until_any".into()), until_any_rule),
-        (Arc::new("repeat".into()), repeat_rule),
-        (Arc::new("lines".into()), lines_rule),
-        (Arc::new("rule".into()), rule_rule),
-        (Arc::new("document".into()), document_rule),
-    ];
-    update_refs(&rules);
-    rules
+    let mut syntax = Syntax {
+        rules: Vec::with_capacity(20),
+        names: Vec::with_capacity(20)
+    };
+    syntax.push((Arc::new("string".into()), string_rule));
+    syntax.push((Arc::new("node".into()), node_rule));
+    syntax.push((Arc::new("set".into()), set_rule));
+    syntax.push((Arc::new("set_opt".into()), set_opt_rule));
+    syntax.push((Arc::new("opt".into()), opt_rule));
+    syntax.push((Arc::new("number".into()), number_rule));
+    syntax.push((Arc::new("text".into()), text_rule));
+    syntax.push((Arc::new("reference".into()), reference_rule));
+    syntax.push((Arc::new("sequence".into()), sequence_rule));
+    syntax.push((Arc::new("select".into()), select_rule));
+    syntax.push((Arc::new("separated_by".into()), separated_by_rule));
+    syntax.push((Arc::new("token".into()), token_rule));
+    syntax.push((Arc::new("optional".into()), optional_rule));
+    syntax.push((Arc::new("whitespace".into()), whitespace_rule));
+    syntax.push((Arc::new("until_any_or_whitespace".into()), until_any_or_whitespace_rule));
+    syntax.push((Arc::new("until_any".into()), until_any_rule));
+    syntax.push((Arc::new("repeat".into()), repeat_rule));
+    syntax.push((Arc::new("lines".into()), lines_rule));
+    syntax.push((Arc::new("rule".into()), rule_rule));
+    syntax.push((Arc::new("document".into()), document_rule));
+    update_refs(&mut syntax);
+    syntax
 }

--- a/src/bootstrap/rules.rs
+++ b/src/bootstrap/rules.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::cell::Cell;
 
 use meta_rules::{
     update_refs,
@@ -89,7 +88,7 @@ pub fn rules() -> Syntax {
                 debug_id: 2007,
                 name: Arc::new("rule".into()),
                 property: Some(Arc::new("rule".into())),
-                index: Cell::new(None),
+                index: None,
             })
         ]
     });
@@ -178,7 +177,7 @@ pub fn rules() -> Syntax {
                     debug_id: 6006,
                     name: Arc::new("set".into()),
                     property: Some(Arc::new("property".into())),
-                    index: Cell::new(None),
+                    index: None,
                 })
             }))
         ]
@@ -220,7 +219,7 @@ pub fn rules() -> Syntax {
                     debug_id: 7007,
                     name: Arc::new("set".into()),
                     property: Some(prop.clone()),
-                    index: Cell::new(None),
+                    index: None,
                 })
             })),
         ]
@@ -248,7 +247,7 @@ pub fn rules() -> Syntax {
                     debug_id: 8005,
                     name: Arc::new("set".into()),
                     property: Some(prop.clone()),
-                    index: Cell::new(None)
+                    index: None
                 })
             }))
         ]
@@ -281,7 +280,7 @@ pub fn rules() -> Syntax {
                     debug_id: 9006,
                     name: Arc::new("rule".into()),
                     property: Some(Arc::new("rule".into())),
-                    index: Cell::new(None)
+                    index: None
                 })
             })),
             Rule::Token(Token {
@@ -321,7 +320,7 @@ pub fn rules() -> Syntax {
                     debug_id: 10006,
                     name: Arc::new("rule".into()),
                     property: Some(Arc::new("rule".into())),
-                    index: Cell::new(None),
+                    index: None,
                 })
             })),
             Rule::Token(Token {
@@ -350,7 +349,7 @@ pub fn rules() -> Syntax {
                 debug_id: 11003,
                 name: Arc::new("opt".into()),
                 property: None,
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Optional(Box::new(Optional {
                 debug_id: 11004,
@@ -377,7 +376,7 @@ pub fn rules() -> Syntax {
                 debug_id: 11008,
                 name: Arc::new("rule".into()),
                 property: Some(Arc::new("by".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Whitespace(Whitespace {
                 debug_id: 11009,
@@ -409,7 +408,7 @@ pub fn rules() -> Syntax {
                 debug_id: 11014,
                 name: Arc::new("rule".into()),
                 property: Some(Arc::new("rule".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Whitespace(Whitespace {
                 debug_id: 11015,
@@ -443,7 +442,7 @@ pub fn rules() -> Syntax {
                 debug_id: 12004,
                 name: Arc::new("set".into()),
                 property: Some(Arc::new("text".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Optional(Box::new(Optional {
                 debug_id: 12005,
@@ -464,7 +463,7 @@ pub fn rules() -> Syntax {
                             debug_id: 12009,
                             name: Arc::new("set".into()),
                             property: Some(prop.clone()),
-                            index: Cell::new(None),
+                            index: None,
                         })
                     ]
                 })
@@ -487,7 +486,7 @@ pub fn rules() -> Syntax {
                 debug_id: 13003,
                 name: Arc::new("rule".into()),
                 property: Some(Arc::new("rule".into())),
-                index: Cell::new(None),
+                index: None,
             })
         ]
     });
@@ -507,7 +506,7 @@ pub fn rules() -> Syntax {
                 debug_id: 14003,
                 name: Arc::new("opt".into()),
                 property: None,
-                index: Cell::new(None),
+                index: None,
             })
         ]
     });
@@ -527,13 +526,13 @@ pub fn rules() -> Syntax {
                 debug_id: 15003,
                 name: Arc::new("set_opt".into()),
                 property: Some(any.clone()),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 15004,
                 name: Arc::new("opt".into()),
                 property: None,
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Optional(Box::new(Optional {
                 debug_id: 15005,
@@ -541,7 +540,7 @@ pub fn rules() -> Syntax {
                     debug_id: 15006,
                     name: Arc::new("set".into()),
                     property: Some(prop.clone()),
-                    index: Cell::new(None),
+                    index: None,
                 })
             }))
         ]
@@ -562,13 +561,13 @@ pub fn rules() -> Syntax {
                 debug_id: 16003,
                 name: Arc::new("set_opt".into()),
                 property: Some(any.clone()),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 16004,
                 name: Arc::new("opt".into()),
                 property: None,
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Optional(Box::new(Optional {
                 debug_id: 16005,
@@ -576,7 +575,7 @@ pub fn rules() -> Syntax {
                     debug_id: 16006,
                     name: Arc::new("set".into()),
                     property: Some(prop.clone()),
-                    index: Cell::new(None),
+                    index: None,
                 })
             }))
         ]
@@ -597,7 +596,7 @@ pub fn rules() -> Syntax {
                 debug_id: 17003,
                 name: Arc::new("opt".into()),
                 property: None,
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Token(Token {
                 debug_id: 17004,
@@ -610,7 +609,7 @@ pub fn rules() -> Syntax {
                 debug_id: 17005,
                 name: Arc::new("rule".into()),
                 property: Some(Arc::new("rule".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Token(Token {
                 debug_id: 17006,
@@ -641,7 +640,7 @@ pub fn rules() -> Syntax {
                 debug_id: 18004,
                 name: Arc::new("rule".into()),
                 property: Some(Arc::new("rule".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Whitespace(Whitespace {
                 debug_id: 18005,
@@ -681,79 +680,79 @@ pub fn rules() -> Syntax {
                 debug_id: 19001,
                 name: Arc::new("whitespace".into()),
                 property: Some(Arc::new("whitespace".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19002,
                 name: Arc::new("until_any_or_whitespace".into()),
                 property: Some(Arc::new("until_any_or_whitespace".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19003,
                 name: Arc::new("until_any".into()),
                 property: Some(Arc::new("until_any".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19004,
                 name: Arc::new("lines".into()),
                 property: Some(Arc::new("lines".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19005,
                 name: Arc::new("repeat".into()),
                 property: Some(Arc::new("repeat".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19006,
                 name: Arc::new("number".into()),
                 property: Some(Arc::new("number".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19007,
                 name: Arc::new("text".into()),
                 property: Some(Arc::new("text".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19008,
                 name: Arc::new("reference".into()),
                 property: Some(Arc::new("reference".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19009,
                 name: Arc::new("sequence".into()),
                 property: Some(Arc::new("sequence".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19010,
                 name: Arc::new("select".into()),
                 property: Some(Arc::new("select".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19011,
                 name: Arc::new("separated_by".into()),
                 property: Some(Arc::new("separated_by".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19012,
                 name: Arc::new("token".into()),
                 property: Some(Arc::new("token".into())),
-                index: Cell::new(None),
+                index: None,
             }),
             Rule::Node(Node {
                 debug_id: 19013,
                 name: Arc::new("optional".into()),
                 property: Some(Arc::new("optional".into())),
-                index: Cell::new(None),
+                index: None,
             }),
         ]
     });
@@ -768,7 +767,7 @@ pub fn rules() -> Syntax {
                     debug_id: 20003,
                     name: Arc::new("string".into()),
                     property: Some(Arc::new("string".into())),
-                    index: Cell::new(None),
+                    index: None,
                 })
             })),
             Rule::Lines(Box::new(Lines {
@@ -777,7 +776,7 @@ pub fn rules() -> Syntax {
                     debug_id: 20005,
                     name: Arc::new("node".into()),
                     property: Some(Arc::new("node".into())),
-                    index: Cell::new(None),
+                    index: None,
                 })
             })),
             Rule::Whitespace(Whitespace {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub use meta_rules::{ parse, Rule };
 /// The type of debug id used to track down errors in rules.
 pub type DebugId = usize;
 
-use std::rc::Rc;
+use std::sync::Arc;
 use std::fs::File;
 use std::path::Path;
 use range::Range;
@@ -36,19 +36,19 @@ mod all {
 #[derive(PartialEq, Clone, Debug)]
 pub enum MetaData {
     /// Starts node.
-    StartNode(Rc<String>),
+    StartNode(Arc<String>),
     /// Ends node.
-    EndNode(Rc<String>),
+    EndNode(Arc<String>),
     /// Sets bool property.
-    Bool(Rc<String>, bool),
+    Bool(Arc<String>, bool),
     /// Sets f64 property.
-    F64(Rc<String>, f64),
+    F64(Arc<String>, f64),
     /// Sets string property.
-    String(Rc<String>, Rc<String>),
+    String(Arc<String>, Arc<String>),
 }
 
 /// Reads syntax from text.
-pub fn syntax(rules: &str) -> Result<Vec<(Rc<String>, Rule)>, (Range, ParseError)> {
+pub fn syntax(rules: &str) -> Result<Vec<(Arc<String>, Rule)>, (Range, ParseError)> {
     match bootstrap::convert(
         &try!(parse(&bootstrap::rules(), rules)),
         &mut vec![] // Ignored meta data
@@ -60,7 +60,7 @@ pub fn syntax(rules: &str) -> Result<Vec<(Rc<String>, Rule)>, (Range, ParseError
 }
 
 /// Reads syntax from text, using the new meta language.
-pub fn syntax2(rules: &str) -> Result<Vec<(Rc<String>, Rule)>, (Range, ParseError)> {
+pub fn syntax2(rules: &str) -> Result<Vec<(Arc<String>, Rule)>, (Range, ParseError)> {
     let new_bootstrap_rules = try!(syntax(include_str!("../assets/better-syntax.txt")));
     match bootstrap::convert(
         &try!(parse(&new_bootstrap_rules, rules)),
@@ -114,4 +114,28 @@ pub fn load_syntax_data2<A, B>(
     let mut d = String::new();
     data_file.read_to_string(&mut d).unwrap();
     stderr_unwrap(&d, parse(&rules, &d))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_thread_safe<T: Send + Sync>() {}
+
+    #[test]
+    fn meta_data_thread_safe() {
+        is_thread_safe::<MetaData>();
+    }
+
+    #[test]
+    fn parse_error_thread_safe() {
+        is_thread_safe::<ParseError>();
+    }
+
+    /*
+    #[test]
+    fn rule_thread_safe() {
+        is_thread_safe::<Rule>();
+    }
+    */
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,33 @@ pub enum MetaData {
     String(Arc<String>, Arc<String>),
 }
 
+/// Stores syntax.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Syntax {
+    /// Rule data.
+    pub rules: Vec<Rule>,
+    /// Name of rules.
+    pub names: Vec<Arc<String>>,
+}
+
+impl Syntax {
+    /// Creates a new syntax.
+    pub fn new() -> Syntax {
+        Syntax {
+            rules: vec![],
+            names: vec![]
+        }
+    }
+
+    /// Adds a new rule.
+    pub fn push(&mut self, (name, rule): (Arc<String>, Rule)) {
+        self.rules.push(rule);
+        self.names.push(name);
+    }
+}
+
 /// Reads syntax from text.
-pub fn syntax(rules: &str) -> Result<Vec<(Arc<String>, Rule)>, (Range, ParseError)> {
+pub fn syntax(rules: &str) -> Result<Syntax, (Range, ParseError)> {
     match bootstrap::convert(
         &try!(parse(&bootstrap::rules(), rules)),
         &mut vec![] // Ignored meta data
@@ -60,7 +85,7 @@ pub fn syntax(rules: &str) -> Result<Vec<(Arc<String>, Rule)>, (Range, ParseErro
 }
 
 /// Reads syntax from text, using the new meta language.
-pub fn syntax2(rules: &str) -> Result<Vec<(Arc<String>, Rule)>, (Range, ParseError)> {
+pub fn syntax2(rules: &str) -> Result<Syntax, (Range, ParseError)> {
     let new_bootstrap_rules = try!(syntax(include_str!("../assets/better-syntax.txt")));
     match bootstrap::convert(
         &try!(parse(&new_bootstrap_rules, rules)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl Syntax {
     }
 
     /// Adds a new rule.
-    pub fn push(&mut self, (name, rule): (Arc<String>, Rule)) {
+    pub fn push(&mut self, name: Arc<String>, rule: Rule) {
         self.rules.push(rule);
         self.names.push(name);
     }
@@ -157,10 +157,13 @@ mod tests {
         is_thread_safe::<ParseError>();
     }
 
-    /*
     #[test]
     fn rule_thread_safe() {
         is_thread_safe::<Rule>();
     }
-    */
+
+    #[test]
+    fn syntax_thread_safe() {
+        is_thread_safe::<Syntax>();
+    }
 }

--- a/src/meta_rules/lines.rs
+++ b/src/meta_rules/lines.rs
@@ -219,7 +219,7 @@ mod tests {
         });
 
         let mut syntax = Syntax::new();
-        syntax.push((Arc::new("".into()), rule));
+        syntax.push(Arc::new("".into()), rule);
         let res = parse(&syntax, text);
         assert_eq!(res, Ok(vec![
             (Range::new(1, 1), MetaData::F64(num.clone(), 1.0)),

--- a/src/meta_rules/lines.rs
+++ b/src/meta_rules/lines.rs
@@ -1,5 +1,5 @@
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -34,7 +34,7 @@ impl Lines {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Rc<String>, Rule)]
+        refs: &[(Arc<String>, Rule)]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let mut state = state.clone();
@@ -93,7 +93,7 @@ mod tests {
     use all::tokenizer::*;
     use meta_rules::{ Lines, Number, Sequence, Text, Whitespace };
     use range::Range;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn fail() {
@@ -136,7 +136,7 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokenizer = vec![];
         let s = TokenizerState::new();
-        let val: Rc<String> = Rc::new("val".into());
+        let val: Arc<String> = Arc::new("val".into());
         let lines = Lines {
             debug_id: 0,
             rule: Rule::Sequence(Sequence {
@@ -172,7 +172,7 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokenizer = vec![];
         let s = TokenizerState::new();
-        let val: Rc<String> = Rc::new("val".into());
+        let val: Arc<String> = Arc::new("val".into());
         let lines = Lines {
             debug_id: 0,
             rule: Rule::Number(Number {
@@ -195,8 +195,8 @@ mod tests {
 \"two\"
 \"three\"
         ";
-        let num: Rc<String> = Rc::new("num".into());
-        let tex: Rc<String> = Rc::new("tex".into());
+        let num: Arc<String> = Arc::new("num".into());
+        let tex: Arc<String> = Arc::new("tex".into());
         let rule = Rule::Sequence(Sequence {
             debug_id: 0,
             args: vec![
@@ -218,14 +218,14 @@ mod tests {
                 }))
             ]
         });
-        let res = parse(&[(Rc::new("".into()), rule)], text);
+        let res = parse(&[(Arc::new("".into()), rule)], text);
         assert_eq!(res, Ok(vec![
             (Range::new(1, 1), MetaData::F64(num.clone(), 1.0)),
             (Range::new(3, 1), MetaData::F64(num.clone(), 2.0)),
             (Range::new(5, 1), MetaData::F64(num.clone(), 3.0)),
-            (Range::new(7, 5), MetaData::String(tex.clone(), Rc::new("one".into()))),
-            (Range::new(13, 5), MetaData::String(tex.clone(), Rc::new("two".into()))),
-            (Range::new(19, 7), MetaData::String(tex.clone(), Rc::new("three".into())))
+            (Range::new(7, 5), MetaData::String(tex.clone(), Arc::new("one".into()))),
+            (Range::new(13, 5), MetaData::String(tex.clone(), Arc::new("two".into()))),
+            (Range::new(19, 7), MetaData::String(tex.clone(), Arc::new("three".into())))
         ]));
     }
 }

--- a/src/meta_rules/lines.rs
+++ b/src/meta_rules/lines.rs
@@ -1,5 +1,4 @@
 use range::Range;
-use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -34,7 +33,7 @@ impl Lines {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Arc<String>, Rule)]
+        refs: &[Rule]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let mut state = state.clone();
@@ -218,7 +217,10 @@ mod tests {
                 }))
             ]
         });
-        let res = parse(&[(Arc::new("".into()), rule)], text);
+
+        let mut syntax = Syntax::new();
+        syntax.push((Arc::new("".into()), rule));
+        let res = parse(&syntax, text);
         assert_eq!(res, Ok(vec![
             (Range::new(1, 1), MetaData::F64(num.clone(), 1.0)),
             (Range::new(3, 1), MetaData::F64(num.clone(), 2.0)),

--- a/src/meta_rules/mod.rs
+++ b/src/meta_rules/mod.rs
@@ -15,11 +15,11 @@ pub use self::until_any::UntilAny;
 pub use self::until_any_or_whitespace::UntilAnyOrWhitespace;
 pub use self::whitespace::Whitespace;
 
-use std::sync::Arc;
 use range::Range;
 use {
     MetaData,
     ParseError,
+    Syntax,
 };
 use tokenizer::TokenizerState;
 
@@ -41,17 +41,17 @@ mod whitespace;
 
 /// Parses text with rules.
 pub fn parse(
-    rules: &[(Arc<String>, Rule)],
+    rules: &Syntax,
     text: &str
 ) -> Result<Vec<(Range, MetaData)>, (Range, ParseError)> {
     let chars: Vec<char> = text.chars().collect();
     let mut tokens = vec![];
     let s = TokenizerState::new();
-    let n = match rules.len() {
+    let n = match rules.rules.len() {
         0 => { return Err((Range::empty(0), ParseError::NoRules)); }
         x => x
     };
-    let res = rules[n - 1].1.parse(&mut tokens, &s, &chars, 0, rules);
+    let res = rules.rules[n - 1].parse(&mut tokens, &s, &chars, 0, &rules.rules);
     match res {
         Ok((range, s, opt_error)) => {
             // Report error if did not reach the end of text.
@@ -73,9 +73,9 @@ pub fn parse(
 }
 
 /// Updates the references such that they point to each other.
-pub fn update_refs(rules: &[(Arc<String>, Rule)]) {
+pub fn update_refs(&mut Syntax { ref mut rules, ref names }: &mut Syntax) {
     for r in rules {
-        r.1.update_refs(rules);
+        r.update_refs(names);
     }
 }
 
@@ -142,7 +142,7 @@ mod tests{
 
     #[test]
     fn no_rules() {
-        assert_eq!(parse(&[], ""),
+        assert_eq!(parse(&Syntax::new(), ""),
             Err((Range::empty(0), ParseError::NoRules)));
     }
 }

--- a/src/meta_rules/mod.rs
+++ b/src/meta_rules/mod.rs
@@ -15,7 +15,7 @@ pub use self::until_any::UntilAny;
 pub use self::until_any_or_whitespace::UntilAnyOrWhitespace;
 pub use self::whitespace::Whitespace;
 
-use std::rc::Rc;
+use std::sync::Arc;
 use range::Range;
 use {
     MetaData,
@@ -41,7 +41,7 @@ mod whitespace;
 
 /// Parses text with rules.
 pub fn parse(
-    rules: &[(Rc<String>, Rule)],
+    rules: &[(Arc<String>, Rule)],
     text: &str
 ) -> Result<Vec<(Range, MetaData)>, (Range, ParseError)> {
     let chars: Vec<char> = text.chars().collect();
@@ -73,7 +73,7 @@ pub fn parse(
 }
 
 /// Updates the references such that they point to each other.
-pub fn update_refs(rules: &[(Rc<String>, Rule)]) {
+pub fn update_refs(rules: &[(Arc<String>, Rule)]) {
     for r in rules {
         r.1.update_refs(rules);
     }

--- a/src/meta_rules/node.rs
+++ b/src/meta_rules/node.rs
@@ -137,8 +137,8 @@ mod tests {
             index: None,
         });
         let mut rules = Syntax::new();
-        rules.push((foo.clone(), node));
-        rules.push((Arc::new("".into()), rule));
+        rules.push(foo.clone(), node);
+        rules.push(Arc::new("".into()), rule);
         update_refs(&mut rules);
 
         let text = "1 2 3";

--- a/src/meta_rules/node.rs
+++ b/src/meta_rules/node.rs
@@ -1,5 +1,5 @@
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::cell::Cell;
 
 use super::{
@@ -19,9 +19,9 @@ use tokenizer::{ read_data, TokenizerState };
 #[derive(Clone, Debug, PartialEq)]
 pub struct Node {
     /// Name of rule.
-    pub name: Rc<String>,
+    pub name: Arc<String>,
     /// The property to set.
-    pub property: Option<Rc<String>>,
+    pub property: Option<Arc<String>>,
     /// A debug id to track down the rule generating an error.
     pub debug_id: DebugId,
     /// The index to the rule reference.
@@ -36,7 +36,7 @@ impl Node {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Rc<String>, Rule)]
+        refs: &[(Arc<String>, Rule)]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let index = match self.index.get() {
@@ -94,14 +94,14 @@ mod tests {
     use all::*;
     use meta_rules::{ update_refs, Node, Number, Optional, Sequence,
         Whitespace };
-    use std::rc::Rc;
+    use std::sync::Arc;
     use std::cell::Cell;
 
     #[test]
     fn node_ref() {
         // Create a node rule the refers to itself.
-        let foo: Rc<String> = Rc::new("foo".into());
-        let num: Rc<String> = Rc::new("num".into());
+        let foo: Arc<String> = Arc::new("foo".into());
+        let num: Arc<String> = Arc::new("num".into());
         let node = Rule::Sequence(Sequence {
             debug_id: 1,
             args: vec![
@@ -140,7 +140,7 @@ mod tests {
         });
         let rules = vec![
             (foo.clone(), node),
-            (Rc::new("".into()), rule)
+            (Arc::new("".into()), rule)
         ];
         update_refs(&rules);
 

--- a/src/meta_rules/node.rs
+++ b/src/meta_rules/node.rs
@@ -1,6 +1,5 @@
 use range::Range;
 use std::sync::Arc;
-use std::cell::Cell;
 
 use super::{
     ret_err,
@@ -25,7 +24,7 @@ pub struct Node {
     /// A debug id to track down the rule generating an error.
     pub debug_id: DebugId,
     /// The index to the rule reference.
-    pub index: Cell<Option<usize>>,
+    pub index: Option<usize>,
 }
 
 impl Node {
@@ -39,7 +38,7 @@ impl Node {
         refs: &[Rule]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
-        let index = match self.index.get() {
+        let index = match self.index {
             None => {
                 return Err((
                     Range::empty(offset),
@@ -95,7 +94,6 @@ mod tests {
     use meta_rules::{ update_refs, Node, Number, Optional, Sequence,
         Whitespace };
     use std::sync::Arc;
-    use std::cell::Cell;
 
     #[test]
     fn node_ref() {
@@ -123,7 +121,7 @@ mod tests {
                                 name: foo.clone(),
                                 property: Some(foo.clone()),
                                 debug_id: 3,
-                                index: Cell::new(None),
+                                index: None,
                             }),
                         ]
                     }),
@@ -136,7 +134,7 @@ mod tests {
             name: foo.clone(),
             property: Some(foo.clone()),
             debug_id: 0,
-            index: Cell::new(None),
+            index: None,
         });
         let mut rules = Syntax::new();
         rules.push((foo.clone(), node));

--- a/src/meta_rules/node.rs
+++ b/src/meta_rules/node.rs
@@ -36,7 +36,7 @@ impl Node {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Arc<String>, Rule)]
+        refs: &[Rule]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let index = match self.index.get() {
@@ -62,7 +62,7 @@ impl Node {
             state.clone()
         };
         let mut opt_error = None;
-        state = match refs[index].1.parse(
+        state = match refs[index].parse(
             tokens, &state, chars, offset, refs
         ) {
             Err(err) => { return Err(ret_err(err, opt_error)); }
@@ -138,11 +138,10 @@ mod tests {
             debug_id: 0,
             index: Cell::new(None),
         });
-        let rules = vec![
-            (foo.clone(), node),
-            (Arc::new("".into()), rule)
-        ];
-        update_refs(&rules);
+        let mut rules = Syntax::new();
+        rules.push((foo.clone(), node));
+        rules.push((Arc::new("".into()), rule));
+        update_refs(&mut rules);
 
         let text = "1 2 3";
         let data = parse(&rules, text).unwrap();

--- a/src/meta_rules/number.rs
+++ b/src/meta_rules/number.rs
@@ -1,6 +1,6 @@
 use range::Range;
 use read_token;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ParseResult,
@@ -16,7 +16,7 @@ use tokenizer::{ read_data, TokenizerState };
 #[derive(Clone, Debug, PartialEq)]
 pub struct Number {
     /// The property to set.
-    pub property: Option<Rc<String>>,
+    pub property: Option<Arc<String>>,
     /// A debug id to track down the rule generating an error.
     pub debug_id: DebugId,
     /// Whether underscore is allowed as visible separator.
@@ -65,7 +65,7 @@ mod tests {
     use all::tokenizer::*;
     use meta_rules::{ Number };
     use range::Range;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn expected_number() {
@@ -102,7 +102,7 @@ mod tests {
         let res = number.parse(&mut tokens, &s, &chars[22..], 22);
         assert_eq!(res, Ok((Range::new(22, 6), s, None)));
 
-        let val: Rc<String> = Rc::new("val".into());
+        let val: Arc<String> = Arc::new("val".into());
         let number = Number {
             debug_id: 0,
             property: Some(val.clone()),

--- a/src/meta_rules/optional.rs
+++ b/src/meta_rules/optional.rs
@@ -1,5 +1,5 @@
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -31,7 +31,7 @@ impl Optional {
         state: &TokenizerState,
         mut chars: &[char],
         mut offset: usize,
-        refs: &[(Rc<String>, Rule)]
+        refs: &[(Arc<String>, Rule)]
     ) -> (Range, TokenizerState, Option<(Range, ParseError)>) {
         let start_offset = offset;
         let mut success_state = state.clone();
@@ -59,7 +59,7 @@ mod tests {
     use all::tokenizer::*;
     use meta_rules::{ Number, Optional, Sequence, Text };
     use range::Range;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn fail_but_continue() {
@@ -67,7 +67,7 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let num: Rc<String> = Rc::new("num".into());
+        let num: Arc<String> = Arc::new("num".into());
         // Will fail because text is expected first.
         let optional = Optional {
             debug_id: 0,

--- a/src/meta_rules/optional.rs
+++ b/src/meta_rules/optional.rs
@@ -1,5 +1,4 @@
 use range::Range;
-use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -31,7 +30,7 @@ impl Optional {
         state: &TokenizerState,
         mut chars: &[char],
         mut offset: usize,
-        refs: &[(Arc<String>, Rule)]
+        refs: &[Rule]
     ) -> (Range, TokenizerState, Option<(Range, ParseError)>) {
         let start_offset = offset;
         let mut success_state = state.clone();

--- a/src/meta_rules/repeat.rs
+++ b/src/meta_rules/repeat.rs
@@ -1,5 +1,5 @@
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -33,7 +33,7 @@ impl Repeat {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Rc<String>, Rule)]
+        refs: &[(Arc<String>, Rule)]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let mut state = state.clone();
@@ -65,7 +65,7 @@ mod tests {
     use all::*;
     use all::tokenizer::*;
     use meta_rules::{ Repeat, Token };
-    use std::rc::Rc;
+    use std::sync::Arc;
     use range::Range;
 
     #[test]
@@ -74,7 +74,7 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let token: Rc<String> = Rc::new("(a)".into());
+        let token: Arc<String> = Arc::new("(a)".into());
         let rule = Repeat {
             debug_id: 0,
             optional: false,
@@ -97,7 +97,7 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let token: Rc<String> = Rc::new("(a)".into());
+        let token: Arc<String> = Arc::new("(a)".into());
         let rule = Repeat {
             debug_id: 0,
             optional: false,

--- a/src/meta_rules/repeat.rs
+++ b/src/meta_rules/repeat.rs
@@ -1,5 +1,4 @@
 use range::Range;
-use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -33,7 +32,7 @@ impl Repeat {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Arc<String>, Rule)]
+        refs: &[Rule]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let mut state = state.clone();

--- a/src/meta_rules/rule.rs
+++ b/src/meta_rules/rule.rs
@@ -113,8 +113,8 @@ impl Rule {
     /// but this can not be borrowed as when the same reference is updated.
     pub fn update_refs(&mut self, names: &[Arc<String>]) {
         match self {
-            &mut Rule::Node(ref p) => {
-                match p.index.get() {
+            &mut Rule::Node(ref mut p) => {
+                match p.index {
                     None => {
                         // Look through references and update if correct name
                         // is found.
@@ -128,7 +128,7 @@ impl Rule {
                         match found {
                             None => { return; }
                             Some(i) => {
-                                p.index.set(Some(i));
+                                p.index = Some(i);
                                 return;
                             }
                         }

--- a/src/meta_rules/rule.rs
+++ b/src/meta_rules/rule.rs
@@ -62,7 +62,7 @@ impl Rule {
         state: &TokenizerState,
         chars: &[char],
         offset: usize,
-        refs: &[(Arc<String>, Rule)]
+        refs: &[Rule]
     ) -> ParseResult<TokenizerState> {
         match self {
             &Rule::Whitespace(ref w) => {
@@ -111,16 +111,16 @@ impl Rule {
     ///
     /// The references contains the name,
     /// but this can not be borrowed as when the same reference is updated.
-    pub fn update_refs(&self, refs: &[(Arc<String>, Rule)]) {
+    pub fn update_refs(&mut self, names: &[Arc<String>]) {
         match self {
-            &Rule::Node(ref p) => {
+            &mut Rule::Node(ref p) => {
                 match p.index.get() {
                     None => {
                         // Look through references and update if correct name
                         // is found.
                         let mut found: Option<usize> = None;
-                        for (i, r) in refs.iter().enumerate() {
-                            if &**p.name == &*r.0 {
+                        for (i, r) in names.iter().enumerate() {
+                            if &**p.name == &**r {
                                 found = Some(i);
                                 break;
                             }
@@ -138,34 +138,34 @@ impl Rule {
                     }
                 };
             }
-            &Rule::Whitespace(_) => {}
-            &Rule::Token(_) => {}
-            &Rule::UntilAny(_) => {}
-            &Rule::UntilAnyOrWhitespace(_) => {}
-            &Rule::Text(_) => {}
-            &Rule::Number(_) => {}
-            &Rule::Select(ref s) => {
-                for sub_rule in &s.args {
-                    sub_rule.update_refs(refs);
+            &mut Rule::Whitespace(_) => {}
+            &mut Rule::Token(_) => {}
+            &mut Rule::UntilAny(_) => {}
+            &mut Rule::UntilAnyOrWhitespace(_) => {}
+            &mut Rule::Text(_) => {}
+            &mut Rule::Number(_) => {}
+            &mut Rule::Select(ref mut s) => {
+                for sub_rule in &mut s.args {
+                    sub_rule.update_refs(names);
                 }
             }
-            &Rule::Sequence(ref s) => {
-                for sub_rule in &s.args {
-                    sub_rule.update_refs(refs);
+            &mut Rule::Sequence(ref mut s) => {
+                for sub_rule in &mut s.args {
+                    sub_rule.update_refs(names);
                 }
             }
-            &Rule::SeparateBy(ref s) => {
-                s.rule.update_refs(refs);
-                s.by.update_refs(refs);
+            &mut Rule::SeparateBy(ref mut s) => {
+                s.rule.update_refs(names);
+                s.by.update_refs(names);
             }
-            &Rule::Repeat(ref r) => {
-                r.rule.update_refs(refs);
+            &mut Rule::Repeat(ref mut r) => {
+                r.rule.update_refs(names);
             }
-            &Rule::Lines(ref l) => {
-                l.rule.update_refs(refs);
+            &mut Rule::Lines(ref mut l) => {
+                l.rule.update_refs(names);
             }
-            &Rule::Optional(ref o) => {
-                o.rule.update_refs(refs);
+            &mut Rule::Optional(ref mut o) => {
+                o.rule.update_refs(names);
             }
         }
     }

--- a/src/meta_rules/rule.rs
+++ b/src/meta_rules/rule.rs
@@ -1,5 +1,5 @@
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     Lines,
@@ -62,7 +62,7 @@ impl Rule {
         state: &TokenizerState,
         chars: &[char],
         offset: usize,
-        refs: &[(Rc<String>, Rule)]
+        refs: &[(Arc<String>, Rule)]
     ) -> ParseResult<TokenizerState> {
         match self {
             &Rule::Whitespace(ref w) => {
@@ -111,7 +111,7 @@ impl Rule {
     ///
     /// The references contains the name,
     /// but this can not be borrowed as when the same reference is updated.
-    pub fn update_refs(&self, refs: &[(Rc<String>, Rule)]) {
+    pub fn update_refs(&self, refs: &[(Arc<String>, Rule)]) {
         match self {
             &Rule::Node(ref p) => {
                 match p.index.get() {

--- a/src/meta_rules/select.rs
+++ b/src/meta_rules/select.rs
@@ -1,5 +1,5 @@
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     err_update,
@@ -30,7 +30,7 @@ impl Select {
         state: &TokenizerState,
         chars: &[char],
         offset: usize,
-        refs: &[(Rc<String>, Rule)]
+        refs: &[(Arc<String>, Rule)]
     ) -> ParseResult<TokenizerState> {
         let mut opt_error: Option<(Range, ParseError)> = None;
         for sub_rule in &self.args {
@@ -58,7 +58,7 @@ mod tests {
     use all::*;
     use meta_rules::{ Number, Select, Text };
     use range::Range;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn invalid_rule() {
@@ -67,7 +67,7 @@ mod tests {
             debug_id: 0,
             args: vec![]
         });
-        let res = parse(&[(Rc::new("".into()), select)], &text);
+        let res = parse(&[(Arc::new("".into()), select)], &text);
         let invalid_rule = match &res {
             &Err((_, ParseError::InvalidRule(_, _))) => true,
             _ => false
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn fail_first() {
         let text = "2";
-        let num: Rc<String> = Rc::new("num".into());
+        let num: Arc<String> = Arc::new("num".into());
         let select = Rule::Select(Select {
             debug_id: 0,
             args: vec![
@@ -94,7 +94,7 @@ mod tests {
                 })
             ]
         });
-        let res = parse(&[(Rc::new("".into()), select)], &text);
+        let res = parse(&[(Arc::new("".into()), select)], &text);
         assert_eq!(res, Ok(vec![
             (Range::new(0, 1), MetaData::F64(num.clone(), 2.0))
         ]));

--- a/src/meta_rules/select.rs
+++ b/src/meta_rules/select.rs
@@ -1,5 +1,4 @@
 use range::Range;
-use std::sync::Arc;
 
 use super::{
     err_update,
@@ -30,7 +29,7 @@ impl Select {
         state: &TokenizerState,
         chars: &[char],
         offset: usize,
-        refs: &[(Arc<String>, Rule)]
+        refs: &[Rule]
     ) -> ParseResult<TokenizerState> {
         let mut opt_error: Option<(Range, ParseError)> = None;
         for sub_rule in &self.args {
@@ -67,7 +66,9 @@ mod tests {
             debug_id: 0,
             args: vec![]
         });
-        let res = parse(&[(Arc::new("".into()), select)], &text);
+        let mut syntax = Syntax::new();
+        syntax.push((Arc::new("".into()), select));
+        let res = parse(&syntax, &text);
         let invalid_rule = match &res {
             &Err((_, ParseError::InvalidRule(_, _))) => true,
             _ => false
@@ -94,7 +95,9 @@ mod tests {
                 })
             ]
         });
-        let res = parse(&[(Arc::new("".into()), select)], &text);
+        let mut syntax = Syntax::new();
+        syntax.push((Arc::new("".into()), select));
+        let res = parse(&syntax, &text);
         assert_eq!(res, Ok(vec![
             (Range::new(0, 1), MetaData::F64(num.clone(), 2.0))
         ]));

--- a/src/meta_rules/select.rs
+++ b/src/meta_rules/select.rs
@@ -67,7 +67,7 @@ mod tests {
             args: vec![]
         });
         let mut syntax = Syntax::new();
-        syntax.push((Arc::new("".into()), select));
+        syntax.push(Arc::new("".into()), select);
         let res = parse(&syntax, &text);
         let invalid_rule = match &res {
             &Err((_, ParseError::InvalidRule(_, _))) => true,
@@ -96,7 +96,7 @@ mod tests {
             ]
         });
         let mut syntax = Syntax::new();
-        syntax.push((Arc::new("".into()), select));
+        syntax.push(Arc::new("".into()), select);
         let res = parse(&syntax, &text);
         assert_eq!(res, Ok(vec![
             (Range::new(0, 1), MetaData::F64(num.clone(), 2.0))

--- a/src/meta_rules/separate_by.rs
+++ b/src/meta_rules/separate_by.rs
@@ -1,5 +1,5 @@
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -37,7 +37,7 @@ impl SeparateBy {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Rc<String>, Rule)]
+        refs: &[(Arc<String>, Rule)]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let mut state = state.clone();
@@ -88,7 +88,7 @@ mod tests {
     use all::*;
     use all::tokenizer::*;
     use meta_rules::{ SeparateBy, Token, UntilAnyOrWhitespace };
-    use std::rc::Rc;
+    use std::sync::Arc;
     use range::Range;
 
     #[test]
@@ -101,13 +101,13 @@ mod tests {
             debug_id: 0,
             rule: Rule::UntilAnyOrWhitespace(UntilAnyOrWhitespace {
                 debug_id: 1,
-                any_characters: Rc::new(",)".into()),
+                any_characters: Arc::new(",)".into()),
                 optional: false,
                 property: None,
             }),
             by: Rule::Token(Token {
                 debug_id: 2,
-                text: Rc::new(",".into()),
+                text: Arc::new(",".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -130,13 +130,13 @@ mod tests {
             debug_id: 0,
             rule: Rule::UntilAnyOrWhitespace(UntilAnyOrWhitespace {
                 debug_id: 1,
-                any_characters: Rc::new(",)".into()),
+                any_characters: Arc::new(",)".into()),
                 optional: false,
                 property: None,
             }),
             by: Rule::Token(Token {
                 debug_id: 2,
-                text: Rc::new(",".into()),
+                text: Arc::new(",".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -155,18 +155,18 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let arg: Rc<String> = Rc::new("arg".into());
+        let arg: Arc<String> = Arc::new("arg".into());
         let sep = SeparateBy {
             debug_id: 0,
             rule: Rule::UntilAnyOrWhitespace(UntilAnyOrWhitespace {
                 debug_id: 1,
-                any_characters: Rc::new(",)".into()),
+                any_characters: Arc::new(",)".into()),
                 optional: false,
                 property: Some(arg.clone()),
             }),
             by: Rule::Token(Token {
                 debug_id: 2,
-                text: Rc::new(",".into()),
+                text: Arc::new(",".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -185,18 +185,18 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let arg: Rc<String> = Rc::new("arg".into());
+        let arg: Arc<String> = Arc::new("arg".into());
         let sep = SeparateBy {
             debug_id: 0,
             rule: Rule::UntilAnyOrWhitespace(UntilAnyOrWhitespace {
                 debug_id: 1,
-                any_characters: Rc::new(",)".into()),
+                any_characters: Arc::new(",)".into()),
                 optional: false,
                 property: Some(arg.clone()),
             }),
             by: Rule::Token(Token {
                 debug_id: 2,
-                text: Rc::new(",".into()),
+                text: Arc::new(",".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -208,9 +208,9 @@ mod tests {
         assert_eq!(res, Ok((Range::new(4, 6), TokenizerState(3),
             Some((Range::new(10, 0), ParseError::ExpectedSomething(1))))));
         assert_eq!(tokens.len(), 3);
-        assert_eq!(&tokens[0].1, &MetaData::String(arg.clone(), Rc::new("a".into())));
-        assert_eq!(&tokens[1].1, &MetaData::String(arg.clone(), Rc::new("b".into())));
-        assert_eq!(&tokens[2].1, &MetaData::String(arg.clone(), Rc::new("c".into())));
+        assert_eq!(&tokens[0].1, &MetaData::String(arg.clone(), Arc::new("a".into())));
+        assert_eq!(&tokens[1].1, &MetaData::String(arg.clone(), Arc::new("b".into())));
+        assert_eq!(&tokens[2].1, &MetaData::String(arg.clone(), Arc::new("c".into())));
     }
 
     #[test]
@@ -219,18 +219,18 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let arg: Rc<String> = Rc::new("arg".into());
+        let arg: Arc<String> = Arc::new("arg".into());
         let sep = SeparateBy {
             debug_id: 0,
             rule: Rule::UntilAnyOrWhitespace(UntilAnyOrWhitespace {
                 debug_id: 1,
-                any_characters: Rc::new(",)".into()),
+                any_characters: Arc::new(",)".into()),
                 optional: false,
                 property: Some(arg.clone()),
             }),
             by: Rule::Token(Token {
                 debug_id: 2,
-                text: Rc::new(",".into()),
+                text: Arc::new(",".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -241,11 +241,11 @@ mod tests {
         let res = sep.parse(&mut tokens, &s, &chars[4..], 4, &[]);
         assert_eq!(res, Ok((Range::new(4, 5), TokenizerState(3),
             Some((Range::new(9, 0),
-                ParseError::ExpectedToken(Rc::new(",".into()), 2))))));
+                ParseError::ExpectedToken(Arc::new(",".into()), 2))))));
         assert_eq!(tokens.len(), 3);
-        assert_eq!(&tokens[0].1, &MetaData::String(arg.clone(), Rc::new("a".into())));
-        assert_eq!(&tokens[1].1, &MetaData::String(arg.clone(), Rc::new("b".into())));
-        assert_eq!(&tokens[2].1, &MetaData::String(arg.clone(), Rc::new("c".into())));
+        assert_eq!(&tokens[0].1, &MetaData::String(arg.clone(), Arc::new("a".into())));
+        assert_eq!(&tokens[1].1, &MetaData::String(arg.clone(), Arc::new("b".into())));
+        assert_eq!(&tokens[2].1, &MetaData::String(arg.clone(), Arc::new("c".into())));
     }
 
     #[test]
@@ -254,20 +254,20 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let arg: Rc<String> = Rc::new("arg".into());
+        let arg: Arc<String> = Arc::new("arg".into());
         let sep = SeparateBy {
             debug_id: 0,
             rule: Rule::SeparateBy(Box::new(SeparateBy {
                 debug_id: 1,
                 rule: Rule::UntilAnyOrWhitespace(UntilAnyOrWhitespace {
                     debug_id: 2,
-                    any_characters: Rc::new(",;".into()),
+                    any_characters: Arc::new(",;".into()),
                     optional: false,
                     property: Some(arg.clone()),
                 }),
                 by: Rule::Token(Token {
                     debug_id: 3,
-                    text: Rc::new(",".into()),
+                    text: Arc::new(",".into()),
                     not: false,
                     inverted: false,
                     property: None,
@@ -277,7 +277,7 @@ mod tests {
             })),
             by: Rule::Token(Token {
                 debug_id: 4,
-                text: Rc::new(";".into()),
+                text: Arc::new(";".into()),
                 not: false,
                 inverted: false,
                 property: None,
@@ -289,10 +289,10 @@ mod tests {
         assert_eq!(res, Ok((Range::new(0, 12), TokenizerState(6),
             Some((Range::new(12, 0), ParseError::ExpectedSomething(2))))));
         assert_eq!(tokens.len(), 6);
-        assert_eq!(&tokens[0].1, &MetaData::String(arg.clone(), Rc::new("a".into())));
-        assert_eq!(&tokens[1].1, &MetaData::String(arg.clone(), Rc::new("b".into())));
-        assert_eq!(&tokens[2].1, &MetaData::String(arg.clone(), Rc::new("c".into())));
-        assert_eq!(&tokens[3].1, &MetaData::String(arg.clone(), Rc::new("d".into())));
-        assert_eq!(&tokens[4].1, &MetaData::String(arg.clone(), Rc::new("e".into())));
+        assert_eq!(&tokens[0].1, &MetaData::String(arg.clone(), Arc::new("a".into())));
+        assert_eq!(&tokens[1].1, &MetaData::String(arg.clone(), Arc::new("b".into())));
+        assert_eq!(&tokens[2].1, &MetaData::String(arg.clone(), Arc::new("c".into())));
+        assert_eq!(&tokens[3].1, &MetaData::String(arg.clone(), Arc::new("d".into())));
+        assert_eq!(&tokens[4].1, &MetaData::String(arg.clone(), Arc::new("e".into())));
     }
 }

--- a/src/meta_rules/separate_by.rs
+++ b/src/meta_rules/separate_by.rs
@@ -1,5 +1,4 @@
 use range::Range;
-use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -37,7 +36,7 @@ impl SeparateBy {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Arc<String>, Rule)]
+        refs: &[Rule]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let mut state = state.clone();

--- a/src/meta_rules/sequence.rs
+++ b/src/meta_rules/sequence.rs
@@ -1,5 +1,5 @@
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -31,7 +31,7 @@ impl Sequence {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Rc<String>, Rule)]
+        refs: &[(Arc<String>, Rule)]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let mut state = state.clone();

--- a/src/meta_rules/sequence.rs
+++ b/src/meta_rules/sequence.rs
@@ -1,5 +1,4 @@
 use range::Range;
-use std::sync::Arc;
 
 use super::{
     ret_err,
@@ -31,7 +30,7 @@ impl Sequence {
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
-        refs: &[(Arc<String>, Rule)]
+        refs: &[Rule]
     ) -> ParseResult<TokenizerState> {
         let mut offset = start_offset;
         let mut state = state.clone();

--- a/src/meta_rules/text.rs
+++ b/src/meta_rules/text.rs
@@ -1,6 +1,6 @@
 use read_token;
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ParseResult,
@@ -18,7 +18,7 @@ pub struct Text {
     /// Whether to allow empty string.
     pub allow_empty: bool,
     /// Which property to set if text is read.
-    pub property: Option<Rc<String>>,
+    pub property: Option<Arc<String>>,
     /// A debug id to track down the rule generating an error.
     pub debug_id: DebugId,
 }
@@ -45,7 +45,7 @@ impl Text {
                         if let Some(ref property) = self.property {
                             Ok((range, read_data(
                                 tokens,
-                                MetaData::String(property.clone(), Rc::new(text)),
+                                MetaData::String(property.clone(), Arc::new(text)),
                                 state,
                                 range
                             ), None))
@@ -68,7 +68,7 @@ mod tests {
     use all::tokenizer::*;
     use meta_rules::Text;
     use range::Range;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn expected_text() {
@@ -107,7 +107,7 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let foo: Rc<String> = Rc::new("foo".into());
+        let foo: Arc<String> = Arc::new("foo".into());
         let text = Text {
             debug_id: 0,
             allow_empty: true,
@@ -117,6 +117,6 @@ mod tests {
         assert_eq!(res, Ok((Range::new(4, 7), TokenizerState(1), None)));
         assert_eq!(tokens.len(), 1);
         assert_eq!(&tokens[0].1,
-            &MetaData::String(foo.clone(), Rc::new("hello".into())));
+            &MetaData::String(foo.clone(), Arc::new("hello".into())));
     }
 }

--- a/src/meta_rules/token.rs
+++ b/src/meta_rules/token.rs
@@ -1,6 +1,6 @@
 use range::Range;
 use read_token;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ParseResult,
@@ -16,13 +16,13 @@ use tokenizer::{ read_data, TokenizerState };
 #[derive(Clone, Debug, PartialEq)]
 pub struct Token {
     /// The text to match against.
-    pub text: Rc<String>,
+    pub text: Arc<String>,
     /// Whether to fail when matching against text.
     pub not: bool,
     /// Whether to set property to true or false (inverted).
     pub inverted: bool,
     /// Which property to set if token matches.
-    pub property: Option<Rc<String>>,
+    pub property: Option<Arc<String>>,
     /// A debug id to track down the rule generating an error.
     pub debug_id: DebugId,
 }
@@ -91,7 +91,7 @@ mod tests {
     use all::*;
     use all::tokenizer::*;
     use meta_rules::Token;
-    use std::rc::Rc;
+    use std::sync::Arc;
     use range::Range;
 
     #[test]
@@ -100,7 +100,7 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let start_parenthesis = Token {
             debug_id: 0,
-            text: Rc::new("(".into()),
+            text: Arc::new("(".into()),
             not: false,
             inverted: false,
             property: None
@@ -110,7 +110,7 @@ mod tests {
         let res = start_parenthesis.parse(&mut tokens, &s, &chars, 0);
         assert_eq!(res, Err((
             Range::new(0, 0),
-            ParseError::ExpectedToken(Rc::new("(".into()), 0)
+            ParseError::ExpectedToken(Arc::new("(".into()), 0)
             ))
         );
     }
@@ -121,7 +121,7 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let start_parenthesis = Token {
             debug_id: 0,
-            text: Rc::new(")".into()),
+            text: Arc::new(")".into()),
             not: true,
             inverted: false,
             property: None
@@ -131,7 +131,7 @@ mod tests {
         let res = start_parenthesis.parse(&mut tokens, &s, &chars, 0);
         assert_eq!(res, Err((
             Range::new(0, 1),
-            ParseError::DidNotExpectToken(Rc::new(")".into()), 0)
+            ParseError::DidNotExpectToken(Arc::new(")".into()), 0)
             ))
         );
     }
@@ -142,7 +142,7 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let fn_ = Token {
             debug_id: 0,
-            text: Rc::new("fn ".into()),
+            text: Arc::new("fn ".into()),
             not: false,
             inverted: false,
             property: None
@@ -155,10 +155,10 @@ mod tests {
 
         // Set bool property.
         let mut tokens = vec![];
-        let has_arguments: Rc<String> = Rc::new("has_arguments".into());
+        let has_arguments: Arc<String> = Arc::new("has_arguments".into());
         let start_parenthesis = Token {
             debug_id: 0,
-            text: Rc::new("(".into()),
+            text: Arc::new("(".into()),
             not: false,
             inverted: false,
             property: Some(has_arguments.clone())
@@ -171,10 +171,10 @@ mod tests {
 
         // Set inverted bool property.
         let mut tokens = vec![];
-        let has_arguments: Rc<String> = Rc::new("has_no_arguments".into());
+        let has_arguments: Arc<String> = Arc::new("has_no_arguments".into());
         let start_parenthesis = Token {
             debug_id: 0,
-            text: Rc::new("(".into()),
+            text: Arc::new("(".into()),
             not: false,
             inverted: true,
             property: Some(has_arguments.clone())

--- a/src/meta_rules/until_any.rs
+++ b/src/meta_rules/until_any.rs
@@ -1,6 +1,6 @@
 use read_token;
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ParseResult,
@@ -16,11 +16,11 @@ use tokenizer::{ read_data, TokenizerState };
 #[derive(Clone, Debug, PartialEq)]
 pub struct UntilAny {
     /// The characters to stop at.
-    pub any_characters: Rc<String>,
+    pub any_characters: Arc<String>,
     /// Whether empty data is accepted or not.
     pub optional: bool,
     /// The property to store read text.
-    pub property: Option<Rc<String>>,
+    pub property: Option<Arc<String>>,
     /// A debug id to track down the rule generating an error.
     pub debug_id: DebugId,
 }
@@ -46,7 +46,7 @@ impl UntilAny {
                 }
                 Ok((range, read_data(
                     tokens,
-                    MetaData::String(property.clone(), Rc::new(text)),
+                    MetaData::String(property.clone(), Arc::new(text)),
                     state,
                     range
                 ), None))
@@ -63,7 +63,7 @@ mod tests {
     use all::tokenizer::*;
     use meta_rules::UntilAny;
     use range::Range;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn required() {
@@ -73,7 +73,7 @@ mod tests {
         let s = TokenizerState::new();
         let name = UntilAny {
             debug_id: 0,
-            any_characters: Rc::new("(".into()),
+            any_characters: Arc::new("(".into()),
             optional: false,
             property: None
         };
@@ -88,10 +88,10 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let function_name: Rc<String> = Rc::new("function_name".into());
+        let function_name: Arc<String> = Arc::new("function_name".into());
         let name = UntilAny {
             debug_id: 0,
-            any_characters: Rc::new("(".into()),
+            any_characters: Arc::new("(".into()),
             optional: false,
             property: Some(function_name.clone())
         };
@@ -99,6 +99,6 @@ mod tests {
         assert_eq!(res, Ok((Range::new(3, 3), TokenizerState(1), None)));
         assert_eq!(tokens.len(), 1);
         assert_eq!(&tokens[0].1,
-            &MetaData::String(function_name.clone(), Rc::new("foo".into())));
+            &MetaData::String(function_name.clone(), Arc::new("foo".into())));
     }
 }

--- a/src/meta_rules/until_any_or_whitespace.rs
+++ b/src/meta_rules/until_any_or_whitespace.rs
@@ -1,6 +1,6 @@
 use read_token;
 use range::Range;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{
     ParseResult,
@@ -16,11 +16,11 @@ use tokenizer::{ read_data, TokenizerState };
 #[derive(Clone, Debug, PartialEq)]
 pub struct UntilAnyOrWhitespace {
     /// The characters to stop at.
-    pub any_characters: Rc<String>,
+    pub any_characters: Arc<String>,
     /// Whether empty data is accepted or not.
     pub optional: bool,
     /// The property to store read text.
-    pub property: Option<Rc<String>>,
+    pub property: Option<Arc<String>>,
     /// A debug id to track down the rule generating an error.
     pub debug_id: DebugId,
 }
@@ -46,7 +46,7 @@ impl UntilAnyOrWhitespace {
                 }
                 Ok((range, read_data(
                     tokens,
-                    MetaData::String(property.clone(), Rc::new(text)),
+                    MetaData::String(property.clone(), Arc::new(text)),
                     state,
                     range
                 ), None))
@@ -63,7 +63,7 @@ mod tests {
     use all::tokenizer::*;
     use meta_rules::UntilAnyOrWhitespace;
     use range::Range;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn required() {
@@ -73,7 +73,7 @@ mod tests {
         let s = TokenizerState::new();
         let name = UntilAnyOrWhitespace {
             debug_id: 0,
-            any_characters: Rc::new("(".into()),
+            any_characters: Arc::new("(".into()),
             optional: false,
             property: None
         };
@@ -88,10 +88,10 @@ mod tests {
         let chars: Vec<char> = text.chars().collect();
         let mut tokens = vec![];
         let s = TokenizerState::new();
-        let function_name: Rc<String> = Rc::new("function_name".into());
+        let function_name: Arc<String> = Arc::new("function_name".into());
         let name = UntilAnyOrWhitespace {
             debug_id: 0,
-            any_characters: Rc::new("(".into()),
+            any_characters: Arc::new("(".into()),
             optional: false,
             property: Some(function_name.clone())
         };
@@ -99,6 +99,6 @@ mod tests {
         assert_eq!(res, Ok((Range::new(3, 3), TokenizerState(1), None)));
         assert_eq!(tokens.len(), 1);
         assert_eq!(&tokens[0].1,
-            &MetaData::String(function_name.clone(), Rc::new("foo".into())));
+            &MetaData::String(function_name.clone(), Arc::new("foo".into())));
     }
 }

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -1,7 +1,7 @@
 use std::fmt::{ Display, Formatter };
 use std::fmt::Error as FormatError;
 use read_token::{ ParseNumberError, ParseStringError };
-use std::rc::Rc;
+use std::sync::Arc;
 
 use DebugId;
 
@@ -25,9 +25,9 @@ pub enum ParseError {
     /// Invalid string format.
     ParseStringError(ParseStringError, DebugId),
     /// Expected token.
-    ExpectedToken(Rc<String>, DebugId),
+    ExpectedToken(Arc<String>, DebugId),
     /// Did not expected token.
-    DidNotExpectToken(Rc<String>, DebugId),
+    DidNotExpectToken(Arc<String>, DebugId),
     /// An invalid rule.
     InvalidRule(&'static str, DebugId),
     /// No rules are specified.


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/meta/issues/274
- Added unit tests for `Send + Sync`
- Separated names to get rid of `Cell`
- Added a `Syntax` struct
- Bumped to 0.16.0
