### PR TITLE
Update to latest range library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A DSL parsing library for human readable text documents"
@@ -11,8 +11,8 @@ repository = "https://github.com/pistondevelopers/meta.git"
 homepage = "https://github.com/pistondevelopers/meta"
 
 [dependencies]
-read_token = "0.3.0"
-range = "0.2.0"
+read_token = "0.4.0"
+range = "0.3.0"
 
 [features]
 unstable = []

--- a/src/json.rs
+++ b/src/json.rs
@@ -6,7 +6,7 @@ use std::io;
 use MetaData;
 
 /// Writes meta data as JSON.
-pub fn write<W>(w: &mut W, data: &[(Range, MetaData)]) -> Result<(), io::Error>
+pub fn write<W>(w: &mut W, data: &[Range<MetaData>]) -> Result<(), io::Error>
     where W: io::Write
 {
     use std::cmp::{ min, max };
@@ -15,21 +15,22 @@ pub fn write<W>(w: &mut W, data: &[(Range, MetaData)]) -> Result<(), io::Error>
 
     // Start indention such that it balances off to zero.
     let starts = data.iter()
-        .filter(|x| if let &(_, MetaData::StartNode(_)) = *x { true } else { false })
+        .filter(|x| if let MetaData::StartNode(_) = x.data { true } else { false })
         .count() as u32;
     let ends = data.iter()
-        .filter(|x| if let &(_, MetaData::EndNode(_)) = *x { true } else { false })
+        .filter(|x| if let MetaData::EndNode(_) = x.data { true } else { false })
         .count() as u32;
     let mut indent: u32 = max(starts, ends) - min(starts, ends);
     let mut first = true;
     for (i, d) in data.iter().enumerate() {
-        let is_end = if let &(_, MetaData::EndNode(_)) = d {
+        let d = &d.data;
+        let is_end = if let MetaData::EndNode(_) = *d {
             indent -= 1;
             true
         } else { false };
         let is_next_end = if i < data.len() - 1 {
-            match &data[i + 1] {
-                &(_, MetaData::EndNode(_)) => false,
+            match data[i + 1].data {
+                MetaData::EndNode(_) => false,
                 _ => true
             }
         } else { true };
@@ -43,25 +44,25 @@ pub fn write<W>(w: &mut W, data: &[(Range, MetaData)]) -> Result<(), io::Error>
         for _ in (0 .. indent_offset + indent) {
             try!(write!(w, " "));
         }
-        match d {
-            &(_, MetaData::StartNode(ref name)) => {
+        match *d {
+            MetaData::StartNode(ref name) => {
                 first = true;
                 try!(write_string(w, name));
                 try!(write!(w, ":{}", "{"));
                 indent += 1;
             }
-            &(_, MetaData::EndNode(_)) => {
+            MetaData::EndNode(_) => {
                 try!(write!(w, "{}", "}"));
             }
-            &(_, MetaData::Bool(ref name, val)) => {
+            MetaData::Bool(ref name, val) => {
                 try!(write_string(w, name));
                 try!(write!(w, ":{}", val));
             }
-            &(_, MetaData::F64(ref name, val)) => {
+            MetaData::F64(ref name, val) => {
                 try!(write_string(w, name));
                 try!(write!(w, ":{}", val));
             }
-            &(_, MetaData::String(ref name, ref val)) => {
+            MetaData::String(ref name, ref val) => {
                 try!(write_string(w, name));
                 try!(write!(w, ":"));
                 try!(write_string(w, val));
@@ -91,7 +92,7 @@ pub fn write_string<W>(w: &mut W, val: &str) -> Result<(), io::Error>
 }
 
 /// Prints meta data.
-pub fn print(data: &[(Range, MetaData)]) {
+pub fn print(data: &[Range<MetaData>]) {
     use std::io::stdout;
 
     write(&mut stdout(), data).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,26 +73,26 @@ impl Syntax {
 }
 
 /// Reads syntax from text.
-pub fn syntax2(rules: &str) -> Result<Syntax, (Range, ParseError)> {
+pub fn syntax2(rules: &str) -> Result<Syntax, Range<ParseError>> {
     match bootstrap::convert(
         &try!(parse(&bootstrap::rules(), rules)),
         &mut vec![] // Ignored meta data
     ) {
         Ok(res) => Ok(res),
-        Err(()) => Err((Range::empty(0), ParseError::Conversion(
-            format!("Bootstrapping rules are incorrect"))))
+        Err(()) => Err((Range::empty(0).wrap(ParseError::Conversion(
+            format!("Bootstrapping rules are incorrect")))))
     }
 }
 
 /// Reads syntax from text, using the new meta language.
-pub fn syntax(rules: &str) -> Result<Syntax, (Range, ParseError)> {
+pub fn syntax(rules: &str) -> Result<Syntax, Range<ParseError>> {
     let new_bootstrap_rules = try!(syntax2(include_str!("../assets/old-self-syntax.txt")));
     match bootstrap::convert(
         &try!(parse(&new_bootstrap_rules, rules)),
         &mut vec![] // Ignored meta data
     ) {
         Ok(res) => Ok(res),
-        Err(()) => Err((Range::empty(0), ParseError::Conversion(
+        Err(()) => Err(Range::empty(0).wrap(ParseError::Conversion(
             format!("Bootstrapping rules are incorrect"))))
     }
 }
@@ -103,7 +103,7 @@ pub fn syntax(rules: &str) -> Result<Syntax, (Range, ParseError)> {
 pub fn load_syntax_data<A, B>(
     syntax_path: A,
     data_path: B
-) -> Vec<(Range, MetaData)>
+) -> Vec<Range<MetaData>>
     where A: AsRef<Path>, B: AsRef<Path>
 {
     use std::io::Read;
@@ -125,7 +125,7 @@ pub fn load_syntax_data<A, B>(
 pub fn load_syntax_data2<A, B>(
     syntax_path: A,
     data_path: B
-) -> Vec<(Range, MetaData)>
+) -> Vec<Range<MetaData>>
     where A: AsRef<Path>, B: AsRef<Path>
 {
     use std::io::Read;

--- a/src/meta_rules/lines.rs
+++ b/src/meta_rules/lines.rs
@@ -29,7 +29,7 @@ impl Lines {
     /// Ignores lines that only contain whitespace characters.
     pub fn parse(
         &self,
-        tokenizer: &mut Vec<(Range, MetaData)>,
+        tokenizer: &mut Vec<Range<MetaData>>,
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
@@ -76,7 +76,7 @@ impl Lines {
                         }
                     };
                 } else {
-                    let err = (Range::new(offset, 0),
+                    let err = Range::new(offset, 0).wrap(
                         ParseError::ExpectedNewLine(self.debug_id));
                     return Err(ret_err(err, opt_error));
                 }
@@ -119,7 +119,7 @@ mod tests {
         };
         let res = lines.parse(&mut tokenizer, &s, &chars, 0, &[]);
         assert_eq!(res, Ok((Range::new(0, 10), s,
-            Some((Range::new(10, 0), ParseError::ExpectedNumber(1))))));
+            Some(Range::new(10, 0).wrap(ParseError::ExpectedNumber(1))))));
     }
 
     #[test]
@@ -154,7 +154,8 @@ mod tests {
             }),
         };
         let res = lines.parse(&mut tokenizer, &s, &chars, 0, &[]);
-        assert_eq!(res, Err((Range::new(8, 0), ParseError::ExpectedNewLine(0))));
+        assert_eq!(res, Err(Range::new(8, 0).wrap(
+            ParseError::ExpectedNewLine(0))));
     }
 
     #[test]
@@ -222,12 +223,15 @@ mod tests {
         syntax.push(Arc::new("".into()), rule);
         let res = parse(&syntax, text);
         assert_eq!(res, Ok(vec![
-            (Range::new(1, 1), MetaData::F64(num.clone(), 1.0)),
-            (Range::new(3, 1), MetaData::F64(num.clone(), 2.0)),
-            (Range::new(5, 1), MetaData::F64(num.clone(), 3.0)),
-            (Range::new(7, 5), MetaData::String(tex.clone(), Arc::new("one".into()))),
-            (Range::new(13, 5), MetaData::String(tex.clone(), Arc::new("two".into()))),
-            (Range::new(19, 7), MetaData::String(tex.clone(), Arc::new("three".into())))
+            Range::new(1, 1).wrap(MetaData::F64(num.clone(), 1.0)),
+            Range::new(3, 1).wrap(MetaData::F64(num.clone(), 2.0)),
+            Range::new(5, 1).wrap(MetaData::F64(num.clone(), 3.0)),
+            Range::new(7, 5).wrap(
+                MetaData::String(tex.clone(), Arc::new("one".into()))),
+            Range::new(13, 5).wrap(
+                MetaData::String(tex.clone(), Arc::new("two".into()))),
+            Range::new(19, 7).wrap(
+                MetaData::String(tex.clone(), Arc::new("three".into())))
         ]));
     }
 }

--- a/src/meta_rules/node.rs
+++ b/src/meta_rules/node.rs
@@ -31,7 +31,7 @@ impl Node {
     /// Parses node.
     pub fn parse(
         &self,
-        tokens: &mut Vec<(Range, MetaData)>,
+        tokens: &mut Vec<Range<MetaData>>,
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
@@ -40,22 +40,21 @@ impl Node {
         let mut offset = start_offset;
         let index = match self.index {
             None => {
-                return Err((
-                    Range::empty(offset),
-                    ParseError::InvalidRule(
-                        "Node rule is not updated to reference",
-                        self.debug_id
-                    )
-                ));
+                return Err(
+                    Range::empty(offset).wrap(
+                        ParseError::InvalidRule(
+                            "Node rule is not updated to reference",
+                            self.debug_id
+                        )
+                    ));
             }
             Some(i) => i
         };
         let mut state = if let Some(ref prop) = self.property {
             read_data(
                 tokens,
-                MetaData::StartNode(prop.clone()),
-                state,
-                Range::empty(offset)
+                Range::empty(offset).wrap(MetaData::StartNode(prop.clone())),
+                state
             )
         } else {
             state.clone()
@@ -76,9 +75,8 @@ impl Node {
             if let Some(ref prop) = self.property {
                 read_data(
                     tokens,
-                    MetaData::EndNode(prop.clone()),
-                    &state,
-                    range
+                    range.wrap(MetaData::EndNode(prop.clone())),
+                    &state
                 )
             } else {
                 state.clone()
@@ -144,14 +142,14 @@ mod tests {
         let text = "1 2 3";
         let data = parse(&rules, text).unwrap();
         assert_eq!(data.len(), 9);
-        assert_eq!(&data[0].1, &MetaData::StartNode(foo.clone()));
-        assert_eq!(&data[1].1, &MetaData::F64(num.clone(), 1.0));
-        assert_eq!(&data[2].1, &MetaData::StartNode(foo.clone()));
-        assert_eq!(&data[3].1, &MetaData::F64(num.clone(), 2.0));
-        assert_eq!(&data[4].1, &MetaData::StartNode(foo.clone()));
-        assert_eq!(&data[5].1, &MetaData::F64(num.clone(), 3.0));
-        assert_eq!(&data[6].1, &MetaData::EndNode(foo.clone()));
-        assert_eq!(&data[7].1, &MetaData::EndNode(foo.clone()));
-        assert_eq!(&data[8].1, &MetaData::EndNode(foo.clone()));
+        assert_eq!(&data[0].data, &MetaData::StartNode(foo.clone()));
+        assert_eq!(&data[1].data, &MetaData::F64(num.clone(), 1.0));
+        assert_eq!(&data[2].data, &MetaData::StartNode(foo.clone()));
+        assert_eq!(&data[3].data, &MetaData::F64(num.clone(), 2.0));
+        assert_eq!(&data[4].data, &MetaData::StartNode(foo.clone()));
+        assert_eq!(&data[5].data, &MetaData::F64(num.clone(), 3.0));
+        assert_eq!(&data[6].data, &MetaData::EndNode(foo.clone()));
+        assert_eq!(&data[7].data, &MetaData::EndNode(foo.clone()));
+        assert_eq!(&data[8].data, &MetaData::EndNode(foo.clone()));
     }
 }

--- a/src/meta_rules/optional.rs
+++ b/src/meta_rules/optional.rs
@@ -26,12 +26,12 @@ impl Optional {
     /// Returns the old state if any sub rule fails.
     pub fn parse(
         &self,
-        tokens: &mut Vec<(Range, MetaData)>,
+        tokens: &mut Vec<Range<MetaData>>,
         state: &TokenizerState,
         mut chars: &[char],
         mut offset: usize,
         refs: &[Rule]
-    ) -> (Range, TokenizerState, Option<(Range, ParseError)>) {
+    ) -> (Range, TokenizerState, Option<Range<ParseError>>) {
         let start_offset = offset;
         let mut success_state = state.clone();
         let mut opt_error = None;
@@ -88,7 +88,7 @@ mod tests {
         };
         let res = optional.parse(&mut tokens, &s, &chars, 0, &[]);
         assert_eq!(res, (Range::new(0, 0), TokenizerState(0),
-            Some((Range::new(0, 0), ParseError::ExpectedText(2)))));
+            Some(Range::new(0, 0).wrap(ParseError::ExpectedText(2)))));
         assert_eq!(tokens.len(), 0);
     }
 }

--- a/src/meta_rules/repeat.rs
+++ b/src/meta_rules/repeat.rs
@@ -28,7 +28,7 @@ impl Repeat {
     /// Parses rule repeatedly.
     pub fn parse(
         &self,
-        tokens: &mut Vec<(Range, MetaData)>,
+        tokens: &mut Vec<Range<MetaData>>,
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
@@ -86,7 +86,7 @@ mod tests {
             })
         };
         let res = rule.parse(&mut tokens, &s, &chars, 0, &[]);
-        assert_eq!(res, Err((Range::new(0, 0),
+        assert_eq!(res, Err(Range::new(0, 0).wrap(
             ParseError::ExpectedToken(token.clone(), 1))))
     }
 
@@ -110,6 +110,6 @@ mod tests {
         };
         let res = rule.parse(&mut tokens, &s, &chars, 0, &[]);
         assert_eq!(res, Ok((Range::new(0, 9), TokenizerState(0),
-            Some((Range::new(9, 0), ParseError::ExpectedToken(token.clone(), 1))))))
+            Some(Range::new(9, 0).wrap(ParseError::ExpectedToken(token.clone(), 1))))))
     }
 }

--- a/src/meta_rules/rule.rs
+++ b/src/meta_rules/rule.rs
@@ -58,7 +58,7 @@ impl Rule {
     /// Parses rule.
     pub fn parse(
         &self,
-        tokens: &mut Vec<(Range, MetaData)>,
+        tokens: &mut Vec<Range<MetaData>>,
         state: &TokenizerState,
         chars: &[char],
         offset: usize,

--- a/src/meta_rules/separate_by.rs
+++ b/src/meta_rules/separate_by.rs
@@ -32,7 +32,7 @@ impl SeparateBy {
     /// Parses rule repeatedly separated by another rule.
     pub fn parse(
         &self,
-        tokens: &mut Vec<(Range, MetaData)>,
+        tokens: &mut Vec<Range<MetaData>>,
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,
@@ -115,7 +115,7 @@ mod tests {
             allow_trail: false,
         };
         let res = sep.parse(&mut tokens, &s, &chars[4..], 4, &[]);
-        assert_eq!(res, Err((Range::new(4, 0),
+        assert_eq!(res, Err(Range::new(4, 0).wrap(
             ParseError::ExpectedSomething(1))));
     }
 
@@ -145,7 +145,7 @@ mod tests {
         };
         let res = sep.parse(&mut tokens, &s, &chars[4..], 4, &[]);
         assert_eq!(res, Ok((Range::new(4, 0), s,
-            Some((Range::new(4, 0), ParseError::ExpectedSomething(1))))));
+            Some(Range::new(4, 0).wrap(ParseError::ExpectedSomething(1))))));
     }
 
     #[test]
@@ -174,7 +174,7 @@ mod tests {
             allow_trail: false,
         };
         let res = sep.parse(&mut tokens, &s, &chars[4..], 4, &[]);
-        assert_eq!(res, Err((Range::new(10, 0),
+        assert_eq!(res, Err(Range::new(10, 0).wrap(
             ParseError::ExpectedSomething(1))));
     }
 
@@ -205,11 +205,14 @@ mod tests {
         };
         let res = sep.parse(&mut tokens, &s, &chars[4..], 4, &[]);
         assert_eq!(res, Ok((Range::new(4, 6), TokenizerState(3),
-            Some((Range::new(10, 0), ParseError::ExpectedSomething(1))))));
+            Some(Range::new(10, 0).wrap(ParseError::ExpectedSomething(1))))));
         assert_eq!(tokens.len(), 3);
-        assert_eq!(&tokens[0].1, &MetaData::String(arg.clone(), Arc::new("a".into())));
-        assert_eq!(&tokens[1].1, &MetaData::String(arg.clone(), Arc::new("b".into())));
-        assert_eq!(&tokens[2].1, &MetaData::String(arg.clone(), Arc::new("c".into())));
+        assert_eq!(&tokens[0].data,
+            &MetaData::String(arg.clone(), Arc::new("a".into())));
+        assert_eq!(&tokens[1].data,
+            &MetaData::String(arg.clone(), Arc::new("b".into())));
+        assert_eq!(&tokens[2].data,
+            &MetaData::String(arg.clone(), Arc::new("c".into())));
     }
 
     #[test]
@@ -239,12 +242,15 @@ mod tests {
         };
         let res = sep.parse(&mut tokens, &s, &chars[4..], 4, &[]);
         assert_eq!(res, Ok((Range::new(4, 5), TokenizerState(3),
-            Some((Range::new(9, 0),
+            Some(Range::new(9, 0).wrap(
                 ParseError::ExpectedToken(Arc::new(",".into()), 2))))));
         assert_eq!(tokens.len(), 3);
-        assert_eq!(&tokens[0].1, &MetaData::String(arg.clone(), Arc::new("a".into())));
-        assert_eq!(&tokens[1].1, &MetaData::String(arg.clone(), Arc::new("b".into())));
-        assert_eq!(&tokens[2].1, &MetaData::String(arg.clone(), Arc::new("c".into())));
+        assert_eq!(&tokens[0].data,
+            &MetaData::String(arg.clone(), Arc::new("a".into())));
+        assert_eq!(&tokens[1].data,
+            &MetaData::String(arg.clone(), Arc::new("b".into())));
+        assert_eq!(&tokens[2].data,
+            &MetaData::String(arg.clone(), Arc::new("c".into())));
     }
 
     #[test]
@@ -286,12 +292,18 @@ mod tests {
         };
         let res = sep.parse(&mut tokens, &s, &chars, 0, &[]);
         assert_eq!(res, Ok((Range::new(0, 12), TokenizerState(6),
-            Some((Range::new(12, 0), ParseError::ExpectedSomething(2))))));
+            Some(Range::new(12, 0).wrap(
+                ParseError::ExpectedSomething(2))))));
         assert_eq!(tokens.len(), 6);
-        assert_eq!(&tokens[0].1, &MetaData::String(arg.clone(), Arc::new("a".into())));
-        assert_eq!(&tokens[1].1, &MetaData::String(arg.clone(), Arc::new("b".into())));
-        assert_eq!(&tokens[2].1, &MetaData::String(arg.clone(), Arc::new("c".into())));
-        assert_eq!(&tokens[3].1, &MetaData::String(arg.clone(), Arc::new("d".into())));
-        assert_eq!(&tokens[4].1, &MetaData::String(arg.clone(), Arc::new("e".into())));
+        assert_eq!(&tokens[0].data,
+            &MetaData::String(arg.clone(), Arc::new("a".into())));
+        assert_eq!(&tokens[1].data,
+            &MetaData::String(arg.clone(), Arc::new("b".into())));
+        assert_eq!(&tokens[2].data,
+            &MetaData::String(arg.clone(), Arc::new("c".into())));
+        assert_eq!(&tokens[3].data,
+            &MetaData::String(arg.clone(), Arc::new("d".into())));
+        assert_eq!(&tokens[4].data,
+            &MetaData::String(arg.clone(), Arc::new("e".into())));
     }
 }

--- a/src/meta_rules/sequence.rs
+++ b/src/meta_rules/sequence.rs
@@ -26,7 +26,7 @@ impl Sequence {
     /// Fails if any sub rule fails.
     pub fn parse(
         &self,
-        tokens: &mut Vec<(Range, MetaData)>,
+        tokens: &mut Vec<Range<MetaData>>,
         state: &TokenizerState,
         mut chars: &[char],
         start_offset: usize,

--- a/src/meta_rules/text.rs
+++ b/src/meta_rules/text.rs
@@ -39,8 +39,10 @@ impl Text {
                 match read_token::parse_string(
                     chars, offset, range.next_offset()) {
                     // Focus range to invalid string format.
-                    Err(err) => Err((err.range(),
-                        ParseError::ParseStringError(err, self.debug_id))),
+                    Err(err) => {
+                        let (r, err) = err.decouple();
+                        Err((r, ParseError::ParseStringError(err, self.debug_id)))
+                    }
                     Ok(text) => {
                         if let Some(ref property) = self.property {
                             Ok((range, read_data(

--- a/src/meta_rules/until_any_or_whitespace.rs
+++ b/src/meta_rules/until_any_or_whitespace.rs
@@ -29,7 +29,7 @@ impl UntilAnyOrWhitespace {
     /// Parses until whitespace or any specified characters.
     pub fn parse(
         &self,
-        tokens: &mut Vec<(Range, MetaData)>,
+        tokens: &mut Vec<Range<MetaData>>,
         state: &TokenizerState,
         chars: &[char],
         offset: usize
@@ -37,7 +37,7 @@ impl UntilAnyOrWhitespace {
         let (range, _) = read_token::until_any_or_whitespace(
             &self.any_characters, chars, offset);
         if range.length == 0 && !self.optional {
-            Err((range, ParseError::ExpectedSomething(self.debug_id)))
+            Err(range.wrap(ParseError::ExpectedSomething(self.debug_id)))
         } else {
             if let Some(ref property) = self.property {
                 let mut text = String::with_capacity(range.length);
@@ -46,9 +46,9 @@ impl UntilAnyOrWhitespace {
                 }
                 Ok((range, read_data(
                     tokens,
-                    MetaData::String(property.clone(), Arc::new(text)),
-                    state,
-                    range
+                    range.wrap(
+                        MetaData::String(property.clone(), Arc::new(text))),
+                    state
                 ), None))
             } else {
                 Ok((range, state.clone(), None))
@@ -78,7 +78,7 @@ mod tests {
             property: None
         };
         let res = name.parse(&mut tokenizer, &s, &chars[3..], 3);
-        assert_eq!(res, Err((Range::new(3, 0),
+        assert_eq!(res, Err(Range::new(3, 0).wrap(
             ParseError::ExpectedSomething(0))));
     }
 
@@ -98,7 +98,7 @@ mod tests {
         let res = name.parse(&mut tokens, &s, &chars[3..], 3);
         assert_eq!(res, Ok((Range::new(3, 3), TokenizerState(1), None)));
         assert_eq!(tokens.len(), 1);
-        assert_eq!(&tokens[0].1,
+        assert_eq!(&tokens[0].data,
             &MetaData::String(function_name.clone(), Arc::new("foo".into())));
     }
 }

--- a/src/meta_rules/whitespace.rs
+++ b/src/meta_rules/whitespace.rs
@@ -20,11 +20,11 @@ impl Whitespace {
     /// If whitespace is required and no whitespace is found,
     /// an error will be reported.
     pub fn parse(&self, chars: &[char], offset: usize) ->
-        Result<Range, (Range, ParseError)>
+        Result<Range, Range<ParseError>>
     {
         let range = read_token::whitespace(chars, offset);
         if range.length == 0 && !self.optional {
-            Err((range, ParseError::ExpectedWhitespace(self.debug_id)))
+            Err(range.wrap(ParseError::ExpectedWhitespace(self.debug_id)))
         } else {
             Ok(range)
         }
@@ -57,6 +57,6 @@ mod tests {
             Ok(Range::new(2, 3)));
         // Prints an error message to standard error output.
         assert_eq!(required_whitespace.parse(&chars[7..], 7),
-            Err((Range::new(7, 0), ParseError::ExpectedWhitespace(0))));
+            Err(Range::new(7, 0).wrap(ParseError::ExpectedWhitespace(0))));
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -8,15 +8,14 @@ use {
 
 /// Reads meta data.
 pub fn read_data(
-    tokens: &mut Vec<(Range, MetaData)>,
-    data: MetaData,
-    state: &TokenizerState,
-    range: Range
+    tokens: &mut Vec<Range<MetaData>>,
+    range_data: Range<MetaData>,
+    state: &TokenizerState
 ) -> TokenizerState {
     if state.0 < tokens.len() {
         tokens.truncate(state.0);
     }
-    tokens.push((range, data));
+    tokens.push(range_data);
     TokenizerState(tokens.len())
 }
 


### PR DESCRIPTION
Depends on https://github.com/PistonDevelopers/read_token/pull/33

TODO:
- [x] Replace `(Range, T)` with `Range<T>`
- [x] Update range version
- [x] Update read_token version
- [x] Bump to 0.18.0
