### PR TITLE
Rename `syntax2` to `syntax`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A DSL parsing library for human readable text documents"

--- a/README.md
+++ b/README.md
@@ -16,42 +16,42 @@ The meta language is used to describe how to read other documents.
 First you define some strings to reuse, then some node rules.
 The last node is used to read the entire document.
 
-`20 "document" [l(@"string""string") l(@"node""node") w?]`
+`20 document = [.l(string:"string") .l(node:"node") .w?]`
 
-Strings are written with name on the left side and the string on right side:
+Strings starts with underscore and can be reused among the rules:
 
-`opt: "optional"`
+`_opt: "optional"`
 
 Nodes start with a number that gets multiplied with 1000 and used as debug id.
 If you get an error `#4003`, then it was caused by a rule in the node starting with 4.
 
 |Rule|Description|
 |----|-----------|
-|l(rule)|Separates sub rule with lines.|
-|r?(rule)|Repeats sub rule until it fails, allows zero repetitions.|
-|r!(rule)|Repeats sub rule until it fails, requires at least one repetition.|
-|...any_characters?name|Reads a string until any characters, allows zero characters. Name is optional.|
-|...any_characters!name|Reads a string until any characters, requires at least one character. Name is optional.|
-|..any_characters?name|Reads a string until any characters or whitespace, allows zero characters. Name is optional.|
-|..any_characters!name|Reads a string until any characters or whitespace, requires at least one character. Name is optional.|
-|w?|Reads whitespace. The whitespace is optional.|
-|w!|Reads whitespace. The whitespace is required.|
+|.l(rule)|Separates sub rule with lines.|
+|.r?(rule)|Repeats sub rule until it fails, allows zero repetitions.|
+|.r!(rule)|Repeats sub rule until it fails, requires at least one repetition.|
+|...any_characters?:name|Reads a string until any characters, allows zero characters. Name is optional.|
+|...any_characters!:name|Reads a string until any characters, requires at least one character. Name is optional.|
+|..any_characters?:name|Reads a string until any characters or whitespace, allows zero characters. Name is optional.|
+|..any_characters!:name|Reads a string until any characters or whitespace, requires at least one character. Name is optional.|
+|.w?|Reads whitespace. The whitespace is optional.|
+|.w!|Reads whitespace. The whitespace is required.|
 |?rule|Makes the rule optional.|
-|"token"name|Expects a token, sets name to `true`. Name is optional.|
-|"token"!name|Expects a token, sets name to `false`. Name is required.|
-|!"token"name|Fails if token is read, sets name to `true` if it is not read. Name is optional.|
-|!"token"!name|Fails if token is read, sets name to `false` if it is not read. Name is required.|
-|s?(by_rule) {rule}|Separates rule by another rule, allows zero repetitions.|
-|s!(by_rule) {rule}|Separates rule by another rule, requires at least one repetition.|
-|s?.(by_rule) {rule}|Separates rule by another rule, allows trailing.|
+|"token":name|Expects a token, sets name to `true`. Name is optional.|
+|"token":!name|Expects a token, sets name to `false`. Name is required.|
+|!"token":name|Fails if token is read, sets name to `true` if it is not read. Name is optional.|
+|!"token":!name|Fails if token is read, sets name to `false` if it is not read. Name is required.|
+|.s?(by_rule rule)|Separates rule by another rule, allows zero repetitions.|
+|.s!(by_rule rule)|Separates rule by another rule, requires at least one repetition.|
+|.s?.(by_rule rule)|Separates rule by another rule, allows trailing.|
 |{rules}|Selects a rule. Tries the first rule, then the second etc. Rules are separated by whitespace.|
 |[rules]|A sequence of rules. Rules are separated by whitespace.|
-|@"node"|Uses a node without a name. The read data is put in the current node.|
-|@"node"name|Uses a node with a name. The read data is put in a new node with the name.|
-|t?name|Reads a JSON string with a name. The string can be empty. Name is optional.|
-|t!name|Reads a JSON string with a name. The string can not be empty. Name is optional.|
-|$name|Reads a number with a name. The name is optional.|
-|$_name|Reads a number with underscore as visible separator, for example `10_000`. The name is optional.|
+|node|Uses a node without a name. The read data is put in the current node.|
+|node:name|Uses a node with a name. The read data is put in a new node with the name.|
+|.t?:name|Reads a JSON string with a name. The string can be empty. Name is optional.|
+|.t!:name|Reads a JSON string with a name. The string can not be empty. Name is optional.|
+|.$:name|Reads a number with a name. The name is optional.|
+|.$_:name|Reads a number with underscore as visible separator, for example `10_000`. The name is optional.|
 
 ### "Hello world" in Piston-Meta
 
@@ -64,16 +64,18 @@ extern crate piston_meta;
 use piston_meta::*;
 
 fn main() {
-    let text = r#"say "Hello world!""#;
-    let rules = r#"1 "rule" ["say" w! t?"foo"]"#;
+    let text = r#"hi James!"#;
+    let rules = r#"
+        1 say_hi = ["hi" .w? {"James":"james" "Peter":"peter"} "!"]
+        2 document = say_hi
+    "#;
     // Parse rules with meta language and convert to rules for parsing text.
     let rules = stderr_unwrap(rules, syntax(rules));
-    let data = stderr_unwrap(text, parse(&rules, text));
-    assert_eq!(data.len(), 1);
-    if let &MetaData::String(_, ref hello) = &data[0].1 {
-        println!("{}", hello);
-    }
+    let mut data = vec![];
+    stderr_unwrap(text, parse(&rules, text, &mut data));
+    json::print(&data);
 }
+
 ```
 
 ### How does it work?

--- a/examples/bootstrap_old.rs
+++ b/examples/bootstrap_old.rs
@@ -15,7 +15,7 @@ fn load_file<P: AsRef<Path>>(path: P) -> String {
 fn main() {
     // Get the old syntax in the new syntax.
     let old = load_file("assets/old-syntax.txt");
-    let old_syntax = stderr_unwrap(&old, syntax2(&old));
+    let old_syntax = stderr_unwrap(&old, syntax(&old));
 
     let old_in_old = load_file("assets/old-self-syntax.txt");
     let mut old_in_old_syntax = vec![];

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -9,7 +9,7 @@ fn main() {
         2 document = say_hi
     "#;
     // Parse rules with meta language and convert to rules for parsing text.
-    let rules = stderr_unwrap(rules, syntax2(rules));
+    let rules = stderr_unwrap(rules, syntax(rules));
     let mut data = vec![];
     stderr_unwrap(text, parse(&rules, text, &mut data));
     json::print(&data);

--- a/examples/key_value.rs
+++ b/examples/key_value.rs
@@ -22,7 +22,7 @@ fn main() {
             } .w?]
         })"##;
     // Parse rules with meta language and convert to rules for parsing text.
-    let rules = stderr_unwrap(rules, syntax2(rules));
+    let rules = stderr_unwrap(rules, syntax(rules));
     let mut data = vec![];
     stderr_unwrap(text, parse(&rules, text, &mut data));
     /* prints

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub fn syntax(rules: &str) -> Result<Syntax, Range<ParseError>> {
     }
 }
 
-/// Convenience method for loading data, using the new meta language.
+/// Convenience method for loading data, using the meta language.
 /// Panics if there is an error, and writes error message to
 /// standard error output.
 pub fn load_syntax_data<A, B>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ impl Syntax {
 }
 
 /// Reads syntax from text.
-pub fn syntax2(rules: &str) -> Result<Syntax, Range<ParseError>> {
+pub fn syntax(rules: &str) -> Result<Syntax, Range<ParseError>> {
     let mut tokens = vec![];
     try!(parse(&bootstrap::rules(), rules, &mut tokens));
     let mut ignored_meta_data = vec![];
@@ -84,20 +84,7 @@ pub fn syntax2(rules: &str) -> Result<Syntax, Range<ParseError>> {
     }
 }
 
-/// Reads syntax from text, using the new meta language.
-pub fn syntax(rules: &str) -> Result<Syntax, Range<ParseError>> {
-    let new_bootstrap_rules = try!(syntax2(include_str!("../assets/old-self-syntax.txt")));
-    let mut tokens = vec![];
-    try!(parse(&new_bootstrap_rules, rules, &mut tokens));
-    let mut ignored_meta_data = vec![];
-    match bootstrap::convert(&tokens, &mut ignored_meta_data) {
-        Ok(res) => Ok(res),
-        Err(()) => Err(Range::empty(0).wrap(ParseError::Conversion(
-            format!("Bootstrapping rules are incorrect"))))
-    }
-}
-
-/// Convenience method for loading data.
+/// Convenience method for loading data, using the new meta language.
 /// Panics if there is an error, and writes error message to
 /// standard error output.
 pub fn load_syntax_data<A, B>(
@@ -112,30 +99,6 @@ pub fn load_syntax_data<A, B>(
     let mut s = String::new();
     syntax_file.read_to_string(&mut s).unwrap();
     let rules = stderr_unwrap(&s, syntax(&s));
-
-    let mut data_file = File::open(data_path).unwrap();
-    let mut d = String::new();
-    data_file.read_to_string(&mut d).unwrap();
-    let mut tokens = vec![];
-    stderr_unwrap(&d, parse(&rules, &d, &mut tokens));
-    tokens
-}
-
-/// Convenience method for loading data, using the new meta language.
-/// Panics if there is an error, and writes error message to
-/// standard error output.
-pub fn load_syntax_data2<A, B>(
-    syntax_path: A,
-    data_path: B
-) -> Vec<Range<MetaData>>
-    where A: AsRef<Path>, B: AsRef<Path>
-{
-    use std::io::Read;
-
-    let mut syntax_file = File::open(syntax_path).unwrap();
-    let mut s = String::new();
-    syntax_file.read_to_string(&mut s).unwrap();
-    let rules = stderr_unwrap(&s, syntax2(&s));
 
     let mut data_file = File::open(data_path).unwrap();
     let mut d = String::new();

--- a/src/search/Cargo.toml
+++ b/src/search/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/pistondevelopers/meta"
 
 [dependencies.piston_meta]
 path = "../../"
-version = "0.21.0"
+version = "0.22.0"
 
 [dependencies]
 range = "0.3.1"


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/meta/issues/264
- Removed the old `syntax`
- Bumped to 0.22.0
