### PR TITLE
Support urls in multi-line comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.24.1"
+version = "0.25.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A DSL parsing library for human readable text documents"

--- a/assets/new-self-syntax.txt
+++ b/assets/new-self-syntax.txt
@@ -1,0 +1,54 @@
+/*
+Used for bootstrapping to test changes in meta language.
+*/
+
+_opt: "optional"
+_inv: "inverted"
+_prop: "property"
+_any: "any_characters"
+_seps: "[]{}():.!?\""
+0 multi_line_comment = ["/*" ..."*/"? .r?({
+    [!"*/" "*" ..."*/"?]
+    [multi_line_comment ..."*/"?]
+    ["/" ..."*/"?]
+}) "*/"]
+1 comment = {multi_line_comment ["//" ..."\n"?]}
+2 string = ["_" .._seps!:"name" ":" .w? .t?:"text"]
+3 node = [.$:"id" .w! !"_" !"." .._seps!:"name" .w? "=" .w? rule:"rule"]
+4 set = {.t!:"value" ["_" .._seps!:"ref"]}
+5 set_opt = {.t?:"value" ["_" .._seps!:"ref"]}
+6 opt = {"?":_opt "!":!_opt}
+7 number = [".$" ?"_":"underscore" ?[":" set:_prop]]
+8 text = [".t" {"?":"allow_empty" "!":!"allow_empty"} ?[":" set:_prop]]
+9 reference = [!"_" !"." .._seps!:"name" ?[":" set:_prop]]
+10 sequence = ["[" .w? .s!.(.w! rule:"rule") "]"]
+11 select = ["{" .w? .s!.(.w! rule:"rule") "}"]
+12 separated_by = [".s" opt ?".":"allow_trail"
+  "(" .w? rule:"by" .w! rule:"rule" .w? ")"]
+13 tag = [?"!":"not" set:"text" ?[":" ?"!":_inv set:_prop]]
+14 optional = ["?" rule:"rule"]
+15 whitespace = [".w" opt]
+16 until_any_or_whitespace = [".." set_opt:_any opt ?[":" set:_prop]]
+17 until_any = ["..." set_opt:_any opt ?[":" set:_prop]]
+18 repeat = [".r" opt "(" rule:"rule" ")"]
+19 lines = [".l(" .w? rule:"rule" .w? ")"]
+20 rule = {
+  whitespace:"whitespace"
+  until_any_or_whitespace:"until_any_or_whitespace"
+  until_any:"until_any"
+  lines:"lines"
+  repeat:"repeat"
+  number:"number"
+  text:"text"
+  reference:"reference"
+  sequence:"sequence"
+  select:"select"
+  separated_by:"separated_by"
+  tag:"tag"
+  optional:"optional"
+}
+21 document = [
+    .l([.w? {string:"string" comment}])
+    .l([.w? {node:"node" comment}])
+    .w?
+]

--- a/assets/self-syntax.txt
+++ b/assets/self-syntax.txt
@@ -111,27 +111,32 @@ _inv: "inverted"
 _prop: "property"
 _any: "any_characters"
 _seps: "[]{}():.!?\""
-0 comment = {["/*" ..."*/"? "*/"] ["//" ..."\n"?]}
-1 string = ["_" .._seps!:"name" ":" .w? .t?:"text"]
-2 node = [.$:"id" .w! !"_" !"." .._seps!:"name" .w? "=" .w? rule:"rule"]
-3 set = {.t!:"value" ["_" .._seps!:"ref"]}
-4 set_opt = {.t?:"value" ["_" .._seps!:"ref"]}
-5 opt = {"?":_opt "!":!_opt}
-6 number = [".$" ?"_":"underscore" ?[":" set:_prop]]
-7 text = [".t" {"?":"allow_empty" "!":!"allow_empty"} ?[":" set:_prop]]
-8 reference = [!"_" !"." .._seps!:"name" ?[":" set:_prop]]
-9 sequence = ["[" .w? .s!.(.w! rule:"rule") "]"]
-10 select = ["{" .w? .s!.(.w! rule:"rule") "}"]
-11 separated_by = [".s" opt ?".":"allow_trail"
+0 multi_line_comment = ["/*" ..."*/"? .r?({
+    [!"*/" "*" ..."*/"?]
+    [multi_line_comment ..."*/"?]
+    ["/" ..."*/"?]
+}) "*/"]
+1 comment = {multi_line_comment ["//" ..."\n"?]}
+2 string = ["_" .._seps!:"name" ":" .w? .t?:"text"]
+3 node = [.$:"id" .w! !"_" !"." .._seps!:"name" .w? "=" .w? rule:"rule"]
+4 set = {.t!:"value" ["_" .._seps!:"ref"]}
+5 set_opt = {.t?:"value" ["_" .._seps!:"ref"]}
+6 opt = {"?":_opt "!":!_opt}
+7 number = [".$" ?"_":"underscore" ?[":" set:_prop]]
+8 text = [".t" {"?":"allow_empty" "!":!"allow_empty"} ?[":" set:_prop]]
+9 reference = [!"_" !"." .._seps!:"name" ?[":" set:_prop]]
+10 sequence = ["[" .w? .s!.(.w! rule:"rule") "]"]
+11 select = ["{" .w? .s!.(.w! rule:"rule") "}"]
+12 separated_by = [".s" opt ?".":"allow_trail"
   "(" .w? rule:"by" .w! rule:"rule" .w? ")"]
-12 tag = [?"!":"not" set:"text" ?[":" ?"!":_inv set:_prop]]
-13 optional = ["?" rule:"rule"]
-14 whitespace = [".w" opt]
-15 until_any_or_whitespace = [".." set_opt:_any opt ?[":" set:_prop]]
-16 until_any = ["..." set_opt:_any opt ?[":" set:_prop]]
-17 repeat = [".r" opt "(" rule:"rule" ")"]
-18 lines = [".l(" .w? rule:"rule" .w? ")"]
-19 rule = {
+13 tag = [?"!":"not" set:"text" ?[":" ?"!":_inv set:_prop]]
+14 optional = ["?" rule:"rule"]
+15 whitespace = [".w" opt]
+16 until_any_or_whitespace = [".." set_opt:_any opt ?[":" set:_prop]]
+17 until_any = ["..." set_opt:_any opt ?[":" set:_prop]]
+18 repeat = [".r" opt "(" rule:"rule" ")"]
+19 lines = [".l(" .w? rule:"rule" .w? ")"]
+20 rule = {
   whitespace:"whitespace"
   until_any_or_whitespace:"until_any_or_whitespace"
   until_any:"until_any"
@@ -146,7 +151,7 @@ _seps: "[]{}():.!?\""
   tag:"tag"
   optional:"optional"
 }
-20 document = [
+21 document = [
     .l([.w? {string:"string" comment}])
     .l([.w? {node:"node" comment}])
     .w?

--- a/src/search/Cargo.toml
+++ b/src/search/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta_search"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "search", "piston"]
 description = "A search API for piston_meta"
@@ -12,7 +12,7 @@ homepage = "https://github.com/pistondevelopers/meta"
 
 [dependencies.piston_meta]
 path = "../../"
-version = "0.24.0"
+version = "0.25.0"
 
 [dependencies]
 range = "0.3.1"

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -50,7 +50,7 @@ fn url_in_multiline_comments() {
         1 say_hi = ["hi" .w? {"James":"james" "Peter":"peter"} "!"]
         2 document = say_hi
     "#;
-    let _ = use_new_self_syntax(rules, text);
+    let _ = use_old_self_syntax(rules, text);
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn star_in_multiline_comments() {
         1 say_hi = ["hi" .w? {"James":"james" "Peter":"peter"} "!"]
         2 document = say_hi
     "#;
-    let _ = use_new_self_syntax(rules, text);
+    let _ = use_old_self_syntax(rules, text);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn nested_multiline_comments() {
         1 say_hi = ["hi" .w? {"James":"james" "Peter":"peter"} "!"]
         2 document = say_hi
     "#;
-    let _ = use_new_self_syntax(rules, text);
+    let _ = use_old_self_syntax(rules, text);
 }
 
 #[test]
@@ -84,5 +84,5 @@ fn nested_multiline_comments_fail() {
         1 say_hi = ["hi" .w? {"James":"james" "Peter":"peter"} "!"]
         2 document = say_hi
     "#;
-    let _ = use_new_self_syntax(rules, text);
+    let _ = use_old_self_syntax(rules, text);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,88 @@
+extern crate piston_meta;
+extern crate range;
+
+use range::Range;
+use piston_meta::*;
+
+pub fn use_new_self_syntax(rules: &str, text: &str) -> Vec<Range<MetaData>> {
+    // Bootstrap rules.
+    let new_self_syntax = include_str!("../assets/new-self-syntax.txt");
+    let bootstrapped_rules = match syntax_errstr(new_self_syntax) {
+        Err(err) => panic!("{}", err),
+        Ok(rules) => rules
+    };
+    // Parse rules with meta language and convert to rules for parsing text.
+    let mut doc_rules = vec![];
+    match parse_errstr(&bootstrapped_rules, rules, &mut doc_rules) {
+        Err(err) => panic!("{}", err),
+        Ok(()) => {}
+    };
+    let mut ignored1 = vec![];
+    let doc_rules = bootstrap::convert(
+        &doc_rules, &mut ignored1).unwrap();
+    // Parse text.
+    let mut data = vec![];
+    match parse_errstr(&doc_rules, text, &mut data) {
+        Err(err) => panic!("{}", err),
+        Ok(()) => {}
+    };
+    data
+}
+
+pub fn use_old_self_syntax(rules: &str, text: &str) -> Vec<Range<MetaData>> {
+    let rules = match syntax_errstr(rules) {
+        Err(err) => panic!("{}", err),
+        Ok(rules) => rules
+    };
+    let mut data = vec![];
+    match parse_errstr(&rules, text, &mut data) {
+        Err(err) => panic!("{}", err),
+        Ok(()) => {}
+    };
+    data
+}
+
+#[test]
+fn url_in_multiline_comments() {
+    let text = r#"hi James!"#;
+    let rules = r#"
+        /* this is an url http://www.piston.rs */
+        1 say_hi = ["hi" .w? {"James":"james" "Peter":"peter"} "!"]
+        2 document = say_hi
+    "#;
+    let _ = use_new_self_syntax(rules, text);
+}
+
+#[test]
+fn star_in_multiline_comments() {
+    let text = r#"hi James!"#;
+    let rules = r#"
+        /* this is a comment with **** and some **** */
+        1 say_hi = ["hi" .w? {"James":"james" "Peter":"peter"} "!"]
+        2 document = say_hi
+    "#;
+    let _ = use_new_self_syntax(rules, text);
+}
+
+#[test]
+fn nested_multiline_comments() {
+    let text = r#"hi James!"#;
+    let rules = r#"
+        /* this is a nested comment /* hey I think /* this */ works */ */
+        1 say_hi = ["hi" .w? {"James":"james" "Peter":"peter"} "!"]
+        2 document = say_hi
+    "#;
+    let _ = use_new_self_syntax(rules, text);
+}
+
+#[test]
+#[should_panic(expected = "Expected: `*/`")]
+fn nested_multiline_comments_fail() {
+    let text = r#"hi James!"#;
+    let rules = r#"
+        /* this is a nested comment /* hey I think /* this works, no? */ */
+        1 say_hi = ["hi" .w? {"James":"james" "Peter":"peter"} "!"]
+        2 document = say_hi
+    "#;
+    let _ = use_new_self_syntax(rules, text);
+}


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/meta/issues/268

Changes self syntax to use improved multi-line comments. Supports urls, `*` and nested comments.
- Bumped to 0.25.0
