### PR TITLE
Fixed bug in error writer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston_meta"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["meta", "language", "encoding", "decoding", "piston"]
 description = "A DSL parsing library for human readable text documents"

--- a/src/parse_error_handler.rs
+++ b/src/parse_error_handler.rs
@@ -44,6 +44,7 @@ impl<'a> ParseErrorHandler<'a> {
         msg: &str
     ) -> Result<(), io::Error> {
         try!(writeln!(w, "{}", msg));
+        let mut printed_pointer = false;
         for (i, &(r, text)) in self.lines.iter().enumerate() {
             if let Some(intersect) = range.ends_intersect(&r) {
                 if intersect.offset >= r.offset {
@@ -55,18 +56,21 @@ impl<'a> ParseErrorHandler<'a> {
                         try!(write!(w, "{}", c));
                     }
                     try!(writeln!(w, ""));
-                    try!(write!(w, "{},{}: ", i + 1, j + 1));
-                    for c in text.chars().skip(s).take(j - s) {
-                        match c {
-                            '\t' => {
-                                try!(write!(w, "\t"));
-                            }
-                            _ => {
-                                try!(write!(w, " "));
+                    if !printed_pointer {
+                        try!(write!(w, "{},{}: ", i + 1, j + 1));
+                        for c in text.chars().skip(s).take(j - s) {
+                            match c {
+                                '\t' => {
+                                    try!(write!(w, "\t"));
+                                }
+                                _ => {
+                                    try!(write!(w, " "));
+                                }
                             }
                         }
+                        try!(writeln!(w, "^"));
+                        printed_pointer = true;
                     }
-                    try!(writeln!(w, "^"));
                 }
             }
         }
@@ -115,6 +119,7 @@ impl<'a> ParseErrorHandler<'a> {
                 }
             }
         }
+        let mut printed_pointer = false;
         for (i, &(r, text)) in self.lines.iter().enumerate() {
             if let Some(intersect) = range.ends_intersect(&r) {
                 if intersect.offset >= r.offset {
@@ -126,18 +131,21 @@ impl<'a> ParseErrorHandler<'a> {
                         try!(write!(w, "{}", c));
                     }
                     try!(writeln!(w, ""));
-                    try!(write!(w, "{},{}: ", i + 1, j + 1));
-                    for c in text.chars().skip(s).take(j - s) {
-                        match c {
-                            '\t' => {
-                                try!(write!(w, "\t"));
-                            }
-                            _ => {
-                                try!(write!(w, " "));
+                    if !printed_pointer {
+                        try!(write!(w, "{},{}: ", i + 1, j + 1));
+                        for c in text.chars().skip(s).take(j - s) {
+                            match c {
+                                '\t' => {
+                                    try!(write!(w, "\t"));
+                                }
+                                _ => {
+                                    try!(write!(w, " "));
+                                }
                             }
                         }
+                        try!(writeln!(w, "^"));
+                        printed_pointer = true;
                     }
-                    try!(writeln!(w, "^"));
                 }
             }
         }


### PR DESCRIPTION
Don’t print the pointer to location in source for more than the first
line.
This bug appeared when an error was reported that spanned multiple
lines in the source.
